### PR TITLE
feat: add multi-task head for defect size classification

### DIFF
--- a/gnn_common/config.py
+++ b/gnn_common/config.py
@@ -21,11 +21,13 @@ class DataConfig:
 @dataclass
 class ModelConfig:
     """モデル設定"""
-    model_type: str = "GCN"  # "GCN" or "GAT"
+    model_type: str = "GCN"  # "GCN", "GAT", or "GATMultiTask"
     hidden_channels: int = 128
     num_classes: int = 19
     dropout: float = 0.2
     num_heads: int = 4  # GAT用
+    multitask: bool = False
+    size_weight: float = 0.5  # multi-task時のsize lossの重み
 
 
 @dataclass

--- a/gnn_common/data_utils.py
+++ b/gnn_common/data_utils.py
@@ -13,6 +13,27 @@ from sklearn.neighbors import NearestNeighbors
 VERBOSE_PRINT = int(os.environ.get("VERBOSE_PRINT", "0") or "0")
 
 
+def extract_size_class(filename):
+    """ファイル名から欠陥サイズクラスを抽出
+
+    Args:
+        filename: データファイル名（例: "L1_B1_el1_H2_W2.npy"）
+
+    Returns:
+        int: 0 (H2_W2=small), 1 (H4_W4=medium), 2 (H8_W8=large), -1 (除外)
+    """
+    SIZE_MAP = {
+        ('2', '2'): 0,  # small
+        ('4', '4'): 1,  # medium
+        ('8', '8'): 2,  # large
+    }
+    match = re.search(r'H(\d+)_W(\d+)', filename)
+    if match:
+        key = (match.group(1), match.group(2))
+        return SIZE_MAP.get(key, -1)
+    return -1
+
+
 def extract_layer_block(file_name):
     """ファイル名から層とブロック番号を抽出（すべてのH_Wサイズに対応）
     
@@ -306,6 +327,9 @@ def prepare_data(pairs, normalized_data_folder, label_data_folder,
         # ファイル名を保存（推論時の対応付けのため）
         data.filename = data_file
         
+        # 欠陥サイズクラスを付与（multi-task学習用）
+        data.size_class = extract_size_class(data_file)
+
         # ファイル単位のminority_ratioを計算して保存（sampler用）
         # minority_ratio = 1 - (count0 / N) で、高いほどminorityが多い
         unique_labels, counts = torch.unique(y, return_counts=True)
@@ -313,7 +337,7 @@ def prepare_data(pairs, normalized_data_folder, label_data_folder,
         count0 = counts[unique_labels == 0].item() if 0 in unique_labels else 0
         minority_ratio = 1.0 - (count0 / total_nodes) if total_nodes > 0 else 0.0
         data.minority_ratio = minority_ratio
-        
+
         data_list.append(data)
         if return_class_weights:
             labels.extend(y.tolist())

--- a/gnn_common/losses.py
+++ b/gnn_common/losses.py
@@ -170,3 +170,47 @@ class FocalLossLogSoftmax(nn.Module):
             return loss.sum()
         else:
             return loss
+
+
+class MultiTaskLoss(nn.Module):
+    """Multi-task loss: 位置分類 + 欠陥サイズ分類
+
+    Args:
+        location_loss_fn: 位置分類用の損失関数（LogitAdjustLoss, FocalLossLogSoftmax 等）
+        size_weight: size loss の重み（デフォルト 0.5）
+    """
+
+    def __init__(self, location_loss_fn, size_weight=0.5):
+        super(MultiTaskLoss, self).__init__()
+        self.location_loss_fn = location_loss_fn
+        self.size_loss_fn = nn.CrossEntropyLoss()
+        self.size_weight = size_weight
+
+    def forward(self, outputs, location_target, size_labels):
+        """
+        Args:
+            outputs: dict {"location": [N, 19], "size": [G, 3]}
+            location_target: [N] ノード単位のクラスインデックス
+            size_labels: [G] グラフ単位のサイズクラス（-1 = 除外）
+
+        Returns:
+            total_loss, dict with individual losses for logging
+        """
+        location_loss = self.location_loss_fn(outputs["location"], location_target)
+
+        # size_class == -1 のグラフを除外
+        size_mask = size_labels >= 0
+        if size_mask.any():
+            size_loss = self.size_loss_fn(
+                outputs["size"][size_mask], size_labels[size_mask]
+            )
+        else:
+            size_loss = torch.tensor(0.0, device=location_loss.device)
+
+        total_loss = location_loss + self.size_weight * size_loss
+
+        return total_loss, {
+            "location_loss": location_loss.detach(),
+            "size_loss": size_loss.detach() if isinstance(size_loss, torch.Tensor) else size_loss,
+            "total_loss": total_loss.detach(),
+        }

--- a/gnn_common/models.py
+++ b/gnn_common/models.py
@@ -2,7 +2,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch_geometric.nn import GCNConv, GATConv
+from torch_geometric.nn import GCNConv, GATConv, global_mean_pool
 
 
 class GCNModel(torch.nn.Module):
@@ -159,7 +159,7 @@ class GATModelWithCrossEdges(torch.nn.Module):
         if self.use_edge_type and hasattr(data, 'edge_type'):
             # 将来の実装: エッジタイプに応じた重み付けなど
             pass
-        
+
         x = F.relu(self.conv1(x, edge_index))
         x = self.dropout(x)
         x = F.relu(self.conv2(x, edge_index))
@@ -169,3 +169,93 @@ class GATModelWithCrossEdges(torch.nn.Module):
         x = F.relu(self.conv4(x, edge_index))
         x = self.fc(x)
         return x
+
+
+class GATMultiTaskModel(torch.nn.Module):
+    """Multi-task GAT: 位置分類（ノード単位）+ 欠陥サイズ分類（グラフ単位）
+
+    共有GATバックボーン（4層）から2つのヘッドに分岐:
+      - head_location: Linear → [N, num_classes] （ノード単位、既存GATModelと同等）
+      - head_size: global_mean_pool → Linear → [G, num_size_classes] （グラフ単位）
+    """
+
+    def __init__(
+        self,
+        hidden_channels=64,
+        num_classes=19,
+        num_size_classes=3,
+        num_heads=4,
+        dropout=0.2,
+    ):
+        super(GATMultiTaskModel, self).__init__()
+        self.conv1 = GATConv(4, hidden_channels, heads=num_heads, concat=True)
+        self.conv2 = GATConv(hidden_channels * num_heads, hidden_channels * 2, heads=num_heads, concat=True)
+        self.conv3 = GATConv(hidden_channels * 2 * num_heads, hidden_channels, heads=num_heads, concat=True)
+        self.conv4 = GATConv(hidden_channels * num_heads, hidden_channels, heads=num_heads, concat=True)
+        self.dropout = nn.Dropout(p=dropout)
+
+        backbone_out = hidden_channels * num_heads
+        self.head_location = nn.Linear(backbone_out, num_classes)
+        self.head_size = nn.Linear(backbone_out, num_size_classes)
+
+        self.init_weights()
+
+    def init_weights(self):
+        """Xavier初期化を適用"""
+        for module in self.modules():
+            if isinstance(module, nn.Linear):
+                nn.init.xavier_uniform_(module.weight)
+                if module.bias is not None:
+                    nn.init.constant_(module.bias, 0)
+            elif isinstance(module, GATConv):
+                if hasattr(module, 'lin_src') and module.lin_src is not None:
+                    nn.init.xavier_uniform_(module.lin_src.weight)
+                    if module.lin_src.bias is not None:
+                        nn.init.constant_(module.lin_src.bias, 0)
+                if hasattr(module, 'lin_dst') and module.lin_dst is not None:
+                    nn.init.xavier_uniform_(module.lin_dst.weight)
+                    if module.lin_dst.bias is not None:
+                        nn.init.constant_(module.lin_dst.bias, 0)
+                if hasattr(module, 'att_src') and module.att_src is not None:
+                    nn.init.xavier_uniform_(module.att_src)
+                if hasattr(module, 'att_dst') and module.att_dst is not None:
+                    nn.init.xavier_uniform_(module.att_dst)
+
+    def _backbone(self, x, edge_index):
+        """共有GATバックボーン"""
+        x = F.relu(self.conv1(x, edge_index))
+        x = self.dropout(x)
+        x = F.relu(self.conv2(x, edge_index))
+        x = self.dropout(x)
+        x = F.relu(self.conv3(x, edge_index))
+        x = self.dropout(x)
+        x = F.relu(self.conv4(x, edge_index))
+        return x
+
+    def forward(self, data, multitask=True):
+        """
+        Args:
+            data: PyG Data / Batch オブジェクト
+            multitask: Falseの場合、既存GATModelと同じ単一テンソル出力
+
+        Returns:
+            multitask=True:  dict {"location": [N, 19], "size": [G, 3]}
+            multitask=False: Tensor [N, 19] （後方互換）
+        """
+        x, edge_index = data.x, data.edge_index
+        batch = data.batch if hasattr(data, 'batch') else None
+
+        shared = self._backbone(x, edge_index)
+
+        location_out = self.head_location(shared)
+
+        if not multitask:
+            return location_out
+
+        if batch is None:
+            batch = torch.zeros(shared.size(0), dtype=torch.long, device=shared.device)
+
+        graph_emb = global_mean_pool(shared, batch)
+        size_out = self.head_size(graph_emb)
+
+        return {"location": location_out, "size": size_out}


### PR DESCRIPTION
## Summary
- Add `GATMultiTaskModel` with shared GAT backbone, node-level location head (19-class) and graph-level size head (3-class: small/medium/large) via `global_mean_pool`
- Add `MultiTaskLoss` combining location + size loss, with `size_class == -1` exclusion for NoiseDefectFree samples
- Add `extract_size_class()` helper in `data_utils.py` to derive size labels from filenames (H2_W2→0, H4_W4→1, H8_W8→2)
- Add `multitask` and `size_weight` fields to `ModelConfig`

## Test plan
- [x] `extract_size_class` unit tests (6 patterns including edge cases)
- [x] Forward pass shape verification (single graph and batched)
- [x] `multitask=False` backward compatibility check
- [x] `MultiTaskLoss` with partial and full `-1` exclusion

Closes #2 (first step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-task learning support added: models can now jointly predict location and size classes.
  * New model variant (GATMultiTask) available with separate outputs for location and size predictions.
  * Automatic size class extraction from dataset metadata, categorizing samples into small, medium, and large.
  * Configurable loss weighting for balancing location and size prediction objectives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->