### PR TITLE
feat: benchmark suite & sample dataset packaging (Issue #5)

### DIFF
--- a/GNN_hole_2026/GNN_program/GNN_zscore_sub_noise_defect_free.py
+++ b/GNN_hole_2026/GNN_program/GNN_zscore_sub_noise_defect_free.py
@@ -2994,10 +2994,23 @@ def main(args):
     np.random.shuffle(all_pairs)
     
     # train/val/testに分割
+    # Benchmark: split_manifest が指定されている場合は外部マニフェストを使用
+    split_manifest_path = getattr(args, "split_manifest", None)
+    if split_manifest_path is not None:
+        import json as _json
+        with open(split_manifest_path, "r") as _f:
+            _manifest = _json.load(_f)
+        if rank == 0:
+            print(f"[BENCHMARK] Using external split manifest: {split_manifest_path}")
+            print(f"[BENCHMARK] Split type: {_manifest.get('split_type', 'unknown')}, seed: {_manifest.get('seed', 'N/A')}")
+        train_pairs = [tuple(p[:2]) for p in _manifest["train"]]
+        val_pairs = [tuple(p[:2]) for p in _manifest["val"]]
+        test_pairs = [tuple(p[:2]) for p in _manifest["test"]]
+        train_data_folder_map = {p[0]: p[2] for p in _manifest["train"]}
+        val_data_folder_map = {p[0]: p[2] for p in _manifest["val"]}
+        test_data_folder_map = {p[0]: p[2] for p in _manifest["test"]}
     # 重要: group単位で分割して leakage (val∩test など) をゼロにする
-    enforce_disjoint_groups = getattr(args, "enforce_disjoint_groups", True)
-    group_key = getattr(args, "group_key", "LBel")
-    if enforce_disjoint_groups:
+    elif getattr(args, "enforce_disjoint_groups", True):
         train_pairs, val_pairs, test_pairs, train_data_folder_map, val_data_folder_map, test_data_folder_map = group_disjoint_split(
             all_pairs,
             train_ratio=0.7,
@@ -4696,6 +4709,11 @@ if __name__ == '__main__':
     
     # Step4: File-level threshold optimization from CSV signals
     parser.add_argument('--optimize_file_thresholds', action='store_true', default=False, help='Run file-level threshold optimization from file_statistics CSV signals (default: False). Saves threshold_optimization_*.csv')
+
+    # Benchmark: external split manifest
+    parser.add_argument('--split_manifest', type=str, default=None,
+                        help='JSON file with pre-computed train/val/test file lists (for benchmark runner). '
+                             'When provided, skips internal splitting and uses the manifest lists.')
 
     args = parser.parse_args()
 

--- a/gnn_common/metrics.py
+++ b/gnn_common/metrics.py
@@ -399,3 +399,90 @@ def calculate_localization_metrics(
         'distance_error': dist_error,
         'auprc': float(auprc)
     }
+
+
+def compute_benchmark_metrics(
+    all_labels: np.ndarray,
+    all_preds: np.ndarray,
+    num_classes: int = 19,
+    all_probs: Optional[np.ndarray] = None,
+    coordinates: Optional[np.ndarray] = None,
+    size_labels: Optional[np.ndarray] = None,
+    size_preds: Optional[np.ndarray] = None,
+) -> Dict[str, any]:
+    """
+    Compute the full standardized benchmark metric suite.
+
+    Composes existing metric functions into a single dict suitable for
+    benchmark comparison tables.
+
+    Args:
+        all_labels: Ground-truth class labels [N]
+        all_preds: Predicted class labels [N]
+        num_classes: Number of classes (default 19)
+        all_probs: Predicted probabilities [N, num_classes] (optional, for top-k / AUPRC)
+        coordinates: Node coordinates [N, 3] (optional, for distance error)
+        size_labels: Ground-truth size class labels [G] (optional, multi-task)
+        size_preds: Predicted size class labels [G] (optional, multi-task)
+
+    Returns:
+        Dictionary with keys:
+            macro_f1, weighted_f1, balanced_accuracy, mcc, accuracy,
+            top_k_accuracy (if all_probs), mean_distance_error (if coordinates),
+            auprc (if all_probs), size_accuracy (if size_labels/preds)
+    """
+    all_labels = np.asarray(all_labels)
+    all_preds = np.asarray(all_preds)
+
+    # --- Core classification metrics from confusion matrix ---
+    cm = confusion_matrix(all_labels, all_preds, labels=list(range(num_classes)))
+    cm_metrics = metrics_from_confusion_matrix(cm)
+
+    result: Dict[str, any] = {
+        "accuracy": cm_metrics["accuracy"],
+        "macro_f1": cm_metrics["macro_f1"],
+        "macro_f1_support_only": cm_metrics["macro_f1_support_only"],
+        "weighted_f1": cm_metrics["weighted_f1"],
+        "weighted_precision": cm_metrics["weighted_precision"],
+        "weighted_recall": cm_metrics["weighted_recall"],
+        "balanced_accuracy": float(balanced_accuracy_score(all_labels, all_preds)),
+        "mcc": float(matthews_corrcoef(all_labels, all_preds)),
+    }
+
+    # --- Localization metrics (require probabilities) ---
+    if all_probs is not None:
+        all_probs = np.asarray(all_probs)
+        top_k = calculate_top_k_accuracy(all_probs, all_labels, top_k_list=[1, 3, 5])
+        result["top_1_accuracy"] = top_k.get(1, np.nan)
+        result["top_3_accuracy"] = top_k.get(3, np.nan)
+        result["top_5_accuracy"] = top_k.get(5, np.nan)
+
+        # AUPRC (binary: defect vs non-defect)
+        defect_class_ids = set(range(1, num_classes))
+        binary_labels = np.array([1 if l in defect_class_ids else 0 for l in all_labels])
+        if len(np.unique(binary_labels)) == 2:
+            defect_probs = all_probs[:, list(defect_class_ids)].sum(axis=1)
+            try:
+                result["auprc"] = float(average_precision_score(binary_labels, defect_probs))
+            except Exception:
+                result["auprc"] = np.nan
+        else:
+            result["auprc"] = np.nan
+
+    # --- Distance error (require probabilities + coordinates) ---
+    if all_probs is not None and coordinates is not None:
+        coordinates = np.asarray(coordinates)
+        dist = calculate_distance_error(all_probs, all_labels, coordinates)
+        result["mean_distance_error"] = dist["mean_distance_error"]
+        result["median_distance_error"] = dist["median_distance_error"]
+
+    # --- Multi-task size accuracy ---
+    if size_labels is not None and size_preds is not None:
+        size_labels = np.asarray(size_labels)
+        size_preds = np.asarray(size_preds)
+        if len(size_labels) > 0:
+            result["size_accuracy"] = float(np.mean(size_labels == size_preds))
+        else:
+            result["size_accuracy"] = np.nan
+
+    return result

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,229 @@
+"""Benchmark suite unit tests."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from gnn_common.metrics import compute_benchmark_metrics
+from tools.benchmark import (
+    load_benchmark_config,
+    generate_run_matrix,
+    aggregate_results,
+    generate_comparison_report,
+)
+from tools.package_sample_dataset import parse_filename
+
+
+class TestComputeBenchmarkMetrics(unittest.TestCase):
+    """Test compute_benchmark_metrics()."""
+
+    def test_basic_classification(self):
+        """Core classification metrics are returned."""
+        rng = np.random.RandomState(42)
+        labels = rng.randint(0, 5, size=200)
+        preds = labels.copy()
+        # Introduce some errors
+        preds[:20] = (preds[:20] + 1) % 5
+
+        result = compute_benchmark_metrics(labels, preds, num_classes=5)
+
+        self.assertIn("accuracy", result)
+        self.assertIn("macro_f1", result)
+        self.assertIn("weighted_f1", result)
+        self.assertIn("balanced_accuracy", result)
+        self.assertIn("mcc", result)
+        self.assertGreater(result["accuracy"], 0.8)
+        self.assertGreater(result["macro_f1"], 0.0)
+
+    def test_with_probabilities(self):
+        """Top-k accuracy and AUPRC are computed when probs provided."""
+        rng = np.random.RandomState(42)
+        n, c = 100, 5
+        labels = rng.randint(0, c, size=n)
+        probs = rng.dirichlet(np.ones(c), size=n)
+        preds = probs.argmax(axis=1)
+
+        result = compute_benchmark_metrics(labels, preds, num_classes=c, all_probs=probs)
+
+        self.assertIn("top_1_accuracy", result)
+        self.assertIn("top_3_accuracy", result)
+        self.assertIn("auprc", result)
+
+    def test_with_size_labels(self):
+        """Size accuracy is computed for multi-task runs."""
+        labels = np.array([0, 0, 1, 1, 2])
+        preds = np.array([0, 0, 1, 2, 2])
+        size_labels = np.array([0, 1, 2])
+        size_preds = np.array([0, 1, 1])
+
+        result = compute_benchmark_metrics(
+            labels, preds, num_classes=3,
+            size_labels=size_labels, size_preds=size_preds,
+        )
+
+        self.assertIn("size_accuracy", result)
+        self.assertAlmostEqual(result["size_accuracy"], 2 / 3)
+
+    def test_perfect_prediction(self):
+        """Perfect predictions yield F1 = 1.0."""
+        labels = np.array([0, 1, 2, 0, 1, 2])
+        preds = labels.copy()
+
+        result = compute_benchmark_metrics(labels, preds, num_classes=3)
+
+        self.assertAlmostEqual(result["accuracy"], 1.0)
+        self.assertAlmostEqual(result["macro_f1"], 1.0, places=5)
+
+
+class TestBenchmarkConfig(unittest.TestCase):
+    """Test config loading and run matrix generation."""
+
+    def test_default_config(self):
+        """Loading with no path returns defaults."""
+        cfg = load_benchmark_config(None)
+        self.assertIn("seeds", cfg)
+        self.assertIn("split_types", cfg)
+        self.assertIsInstance(cfg["seeds"], list)
+
+    def test_yaml_config(self):
+        """Loading from YAML file works."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("benchmark:\n  seeds: [1, 2]\n  split_types:\n    - type: iid\n")
+            f.flush()
+            cfg = load_benchmark_config(f.name)
+
+        self.assertEqual(cfg["seeds"], [1, 2])
+        Path(f.name).unlink()
+
+    def test_missing_config_file(self):
+        """Missing config file falls back to defaults."""
+        cfg = load_benchmark_config("/nonexistent/path.yaml")
+        self.assertIn("seeds", cfg)
+
+
+class TestRunMatrix(unittest.TestCase):
+    """Test run matrix generation."""
+
+    def test_matrix_size(self):
+        """Matrix has correct number of entries."""
+        cfg = {
+            "seeds": [42, 84],
+            "split_types": [{"type": "iid"}, {"type": "layer", "params": {"train_layers": [1]}}],
+            "models": [{"name": "GAT", "args": {}}],
+            "output": {"prefix": "test"},
+        }
+        matrix = generate_run_matrix(cfg)
+        self.assertEqual(len(matrix), 4)  # 2 seeds x 2 splits x 1 model
+
+    def test_run_ids_unique(self):
+        """All run IDs in the matrix are unique."""
+        cfg = {
+            "seeds": [42, 84, 126],
+            "split_types": [{"type": "iid"}, {"type": "defect_size"}],
+            "models": [{"name": "GAT", "args": {}}],
+            "output": {"prefix": "bench"},
+        }
+        matrix = generate_run_matrix(cfg)
+        run_ids = [m["run_id"] for m in matrix]
+        self.assertEqual(len(run_ids), len(set(run_ids)))
+
+    def test_matrix_contents(self):
+        """Each run spec contains required keys."""
+        cfg = {
+            "seeds": [42],
+            "split_types": [{"type": "iid"}],
+            "models": [{"name": "M", "args": {"lr": 0.01}}],
+            "output": {"prefix": "t"},
+        }
+        matrix = generate_run_matrix(cfg)
+        spec = matrix[0]
+        self.assertIn("run_id", spec)
+        self.assertIn("seed", spec)
+        self.assertIn("split_type", spec)
+        self.assertIn("model_args", spec)
+        self.assertEqual(spec["seed"], 42)
+        self.assertEqual(spec["split_type"], "iid")
+
+
+class TestAggregateResults(unittest.TestCase):
+    """Test result aggregation."""
+
+    def test_aggregate_empty(self):
+        """Empty input produces empty DataFrame."""
+        df = aggregate_results([])
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(len(df), 0)
+
+    def test_aggregate_basic(self):
+        """Basic aggregation produces correct columns."""
+        results = [
+            {
+                "run_info": {"run_id": "r1", "split_type": "iid", "seed": 42, "model_name": "GAT"},
+                "metrics": {
+                    "summary": {"exit_code": 0},
+                    "metrics": {
+                        "test": {"accuracy": 0.95, "macro_f1": 0.8, "weighted_f1": 0.9,
+                                 "balanced_accuracy": 0.85, "mcc": 0.7},
+                        "best": {"epoch": 100, "macro_f1": 0.82},
+                    },
+                },
+            }
+        ]
+        df = aggregate_results(results)
+        self.assertEqual(len(df), 1)
+        self.assertAlmostEqual(df.iloc[0]["test_macro_f1"], 0.8)
+
+
+class TestReportGeneration(unittest.TestCase):
+    """Test report output."""
+
+    def test_generates_files(self):
+        """Report generates CSV, JSON, and summary files."""
+        df = pd.DataFrame({
+            "run_id": ["r1"],
+            "split_type": ["iid"],
+            "test_macro_f1": [0.8],
+            "test_weighted_f1": [0.9],
+            "test_balanced_accuracy": [0.85],
+            "test_mcc": [0.7],
+        })
+        with tempfile.TemporaryDirectory() as tmp:
+            generate_comparison_report(df, Path(tmp))
+            self.assertTrue((Path(tmp) / "benchmark_results.csv").exists())
+            self.assertTrue((Path(tmp) / "benchmark_results.json").exists())
+            self.assertTrue((Path(tmp) / "benchmark_summary.txt").exists())
+
+
+class TestParseFilename(unittest.TestCase):
+    """Test filename parsing for sample dataset packager."""
+
+    def test_defect_file(self):
+        meta = parse_filename("Defect_L10_B100_el1165_H4_W4.npy")
+        self.assertEqual(meta["type"], "defect")
+        self.assertEqual(meta["layer"], 10)
+        self.assertEqual(meta["h"], 4)
+        self.assertEqual(meta["size_class"], "medium")
+
+    def test_small_defect(self):
+        meta = parse_filename("Defect_L1_B1_el100_H2_W2.npy")
+        self.assertEqual(meta["size_class"], "small")
+
+    def test_large_defect(self):
+        meta = parse_filename("Defect_L2_B50_el500_H8_W8.npy")
+        self.assertEqual(meta["size_class"], "large")
+
+    def test_noise_defect_free(self):
+        meta = parse_filename("NoiseDefectFree_something.npy")
+        self.assertEqual(meta["type"], "noise_defect_free")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""
+Reproducible benchmark runner for CFRP GNN defect localization.
+
+Orchestrates a matrix of (split_type x seed) training runs via launch_run.py,
+collects standardized metrics, and produces comparison tables.
+
+Usage:
+    # Full benchmark from config
+    python tools/benchmark.py --config tools/benchmark_config.yaml
+
+    # Single split type with custom seeds
+    python tools/benchmark.py --split_types iid --seeds 42 84 126
+
+    # Re-aggregate existing runs (skip training)
+    python tools/benchmark.py --collect_only --run_dirs runs/bench_*
+
+    # Dry run (print commands without executing)
+    python tools/benchmark.py --config tools/benchmark_config.yaml --dry_run
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+import yaml
+
+# Project root
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.compare_runs import load_run_metrics, create_comparison_table
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+def load_benchmark_config(config_path: Optional[str] = None) -> Dict[str, Any]:
+    """Load benchmark configuration from YAML file or return defaults."""
+    defaults = {
+        "name": "cfrp_gnn_benchmark",
+        "seeds": [42],
+        "split_types": [{"type": "iid"}],
+        "models": [{
+            "name": "GAT_base",
+            "args": {
+                "hidden_channels": 16,
+                "learning_rate": 0.002,
+                "epochs": 500,
+                "patience": 100,
+                "batch_size": 64,
+                "dropout": 0.10,
+                "edge_drop": 0.01,
+                "use_amp": True,
+                "use_class_frequency_sampler": True,
+            },
+        }],
+        "hardware": {"nproc_per_node": 4},
+        "data": {
+            "data_dir": "GNN_hole_2026/all_sub_hole_defect_zscore",
+            "label_dir": "GNN_hole_2026/all_19class_label",
+            "num_classes": 19,
+        },
+        "output": {"base_dir": "runs", "prefix": "bench"},
+    }
+
+    if config_path is None:
+        return defaults
+
+    path = Path(config_path)
+    if not path.exists():
+        print(f"[WARN] Config file not found: {path}, using defaults")
+        return defaults
+
+    with open(path, "r") as f:
+        raw = yaml.safe_load(f)
+
+    cfg = raw.get("benchmark", raw)
+    # Merge with defaults (shallow)
+    for key, val in defaults.items():
+        cfg.setdefault(key, val)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Run matrix generation
+# ---------------------------------------------------------------------------
+
+def generate_run_matrix(config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Expand config into a list of individual run specifications."""
+    seeds = config.get("seeds", [42])
+    split_types = config.get("split_types", [{"type": "iid"}])
+    models = config.get("models", [{}])
+    prefix = config.get("output", {}).get("prefix", "bench")
+
+    matrix = []
+    for model_cfg in models:
+        model_name = model_cfg.get("name", "default")
+        model_args = model_cfg.get("args", {})
+        for split_cfg in split_types:
+            split_type = split_cfg["type"]
+            split_params = split_cfg.get("params", {})
+            for seed in seeds:
+                run_id = f"{prefix}_{split_type}_s{seed}_{model_name}"
+                matrix.append({
+                    "run_id": run_id,
+                    "seed": seed,
+                    "split_type": split_type,
+                    "split_params": split_params,
+                    "model_name": model_name,
+                    "model_args": model_args,
+                })
+    return matrix
+
+
+# ---------------------------------------------------------------------------
+# Split manifest creation
+# ---------------------------------------------------------------------------
+
+def create_split_manifest(
+    split_type: str,
+    seed: int,
+    split_params: Dict[str, Any],
+    data_config: Dict[str, Any],
+    output_dir: Path,
+) -> Path:
+    """Create a split manifest JSON using gnn_common.data_utils.create_ood_split."""
+    from gnn_common.data_utils import create_ood_split, create_data_label_pairs
+
+    data_dir = str(REPO_ROOT / data_config["data_dir"])
+    label_dir = str(REPO_ROOT / data_config["label_dir"])
+
+    # Gather all data-label pairs from the data directories
+    all_pairs_with_folders = []
+
+    # Check for subdirectory structure (train/val/test) or flat
+    data_path = Path(data_dir)
+    subdirs = [d for d in data_path.iterdir() if d.is_dir() and d.name in ("train", "val", "test")]
+
+    if subdirs:
+        # Data is already in subdirs — gather all files across them
+        for subdir in sorted(data_path.iterdir()):
+            if not subdir.is_dir():
+                continue
+            files = sorted(f.name for f in subdir.iterdir() if f.suffix == ".npy")
+            for fname in files:
+                base = os.path.splitext(fname)[0]
+                label_fname = f"{base}_19label.npy"
+                label_path = Path(label_dir) / label_fname
+                if label_path.exists():
+                    all_pairs_with_folders.append((fname, label_fname, str(subdir)))
+    else:
+        # Flat directory
+        files = sorted(f.name for f in data_path.iterdir() if f.suffix == ".npy")
+        for fname in files:
+            base = os.path.splitext(fname)[0]
+            label_fname = f"{base}_19label.npy"
+            label_path = Path(label_dir) / label_fname
+            if label_path.exists():
+                all_pairs_with_folders.append((fname, label_fname, data_dir))
+
+    if not all_pairs_with_folders:
+        raise RuntimeError(f"No data-label pairs found in {data_dir}")
+
+    # Use create_ood_split for the split
+    pairs = [(p[0], p[1]) for p in all_pairs_with_folders]
+    folder_map = {p[0]: p[2] for p in all_pairs_with_folders}
+
+    # OOD splits require label_data_folder
+    ood_kwargs = dict(split_params)
+    if split_type != "iid":
+        ood_kwargs["label_data_folder"] = str(REPO_ROOT / data_config["label_dir"])
+
+    train_pairs, val_pairs, test_pairs = create_ood_split(
+        pairs=pairs,
+        split_type=split_type,
+        seed=seed,
+        **ood_kwargs,
+    )
+
+    # Build manifest with folder info
+    manifest = {
+        "split_type": split_type,
+        "seed": seed,
+        "split_params": split_params,
+        "train": [[p[0], p[1], folder_map.get(p[0], "")] for p in train_pairs],
+        "val": [[p[0], p[1], folder_map.get(p[0], "")] for p in val_pairs],
+        "test": [[p[0], p[1], folder_map.get(p[0], "")] for p in test_pairs],
+    }
+
+    manifest_path = output_dir / f"split_manifest_{split_type}_s{seed}.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2, ensure_ascii=False)
+
+    print(f"[BENCHMARK] Created split manifest: {manifest_path}")
+    print(f"  train={len(manifest['train'])}, val={len(manifest['val'])}, test={len(manifest['test'])}")
+    return manifest_path
+
+
+# ---------------------------------------------------------------------------
+# Single run execution
+# ---------------------------------------------------------------------------
+
+def execute_single_run(
+    run_spec: Dict[str, Any],
+    config: Dict[str, Any],
+    output_base: Path,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Execute a single benchmark run via launch_run.py."""
+    run_id = run_spec["run_id"]
+    model_args = run_spec["model_args"]
+    hardware = config.get("hardware", {})
+    nproc = hardware.get("nproc_per_node", 4)
+
+    # Create split manifest
+    manifest_dir = output_base / "manifests"
+    data_config = config.get("data", {})
+
+    try:
+        manifest_path = create_split_manifest(
+            split_type=run_spec["split_type"],
+            seed=run_spec["seed"],
+            split_params=run_spec["split_params"],
+            data_config=data_config,
+            output_dir=manifest_dir,
+        )
+    except Exception as e:
+        print(f"[ERROR] Failed to create split manifest for {run_id}: {e}")
+        return {"run_id": run_id, "status": "manifest_error", "error": str(e)}
+
+    # Build training args
+    training_args = ["--"]
+    for key, val in model_args.items():
+        arg_key = f"--{key}"
+        if isinstance(val, bool):
+            if val:
+                training_args.append(arg_key)
+        else:
+            training_args.extend([arg_key, str(val)])
+
+    # Add split manifest
+    training_args.extend(["--split_manifest", str(manifest_path)])
+
+    # Build launch_run.py command
+    launcher = str(REPO_ROOT / "tools" / "launch_run.py")
+    cmd = [
+        sys.executable, launcher,
+        "--run_id", run_id,
+        "--output_base", str(output_base),
+        "--nproc_per_node", str(nproc),
+    ]
+    if dry_run:
+        cmd.append("--dry_run")
+    cmd.extend(training_args)
+
+    run_dir = output_base / run_id
+
+    print(f"\n{'='*60}")
+    print(f"[BENCHMARK] {'DRY RUN: ' if dry_run else ''}Starting run: {run_id}")
+    print(f"  split_type={run_spec['split_type']}, seed={run_spec['seed']}")
+    print(f"  cmd: {' '.join(cmd)}")
+    print(f"{'='*60}\n")
+
+    if dry_run:
+        # Still execute launch_run.py in dry_run mode to show the command
+        subprocess.run(cmd, cwd=str(REPO_ROOT))
+        return {"run_id": run_id, "run_dir": str(run_dir), "status": "dry_run"}
+
+    result = subprocess.run(cmd, cwd=str(REPO_ROOT))
+    return {
+        "run_id": run_id,
+        "run_dir": str(run_dir),
+        "exit_code": result.returncode,
+        "status": "completed" if result.returncode == 0 else "failed",
+        "split_type": run_spec["split_type"],
+        "seed": run_spec["seed"],
+        "model_name": run_spec["model_name"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Metric collection
+# ---------------------------------------------------------------------------
+
+def collect_run_metrics(run_dir: Path) -> Dict[str, Any]:
+    """Load metrics from a completed run directory.
+
+    Reuses compare_runs.load_run_metrics() and augments with benchmark metadata.
+    """
+    metrics = load_run_metrics(run_dir)
+
+    # Try to load the split manifest metadata
+    meta_dir = run_dir / "meta"
+    run_config_path = meta_dir / "run_config.json"
+    if run_config_path.exists():
+        with open(run_config_path) as f:
+            run_config = json.load(f)
+        metrics["run_config"] = run_config
+
+    return metrics
+
+
+def aggregate_results(all_results: List[Dict[str, Any]]) -> pd.DataFrame:
+    """Flatten nested metric dicts into a single DataFrame."""
+    rows = []
+    for result in all_results:
+        run_info = result.get("run_info", {})
+        metrics = result.get("metrics", {})
+
+        summary = metrics.get("summary", {})
+        test_metrics = metrics.get("metrics", {}).get("test", {})
+        best_metrics = metrics.get("metrics", {}).get("best", {})
+
+        row = {
+            "run_id": run_info.get("run_id", metrics.get("run_id", "unknown")),
+            "split_type": run_info.get("split_type", ""),
+            "seed": run_info.get("seed", ""),
+            "model_name": run_info.get("model_name", ""),
+            "exit_code": summary.get("exit_code"),
+            "best_epoch": best_metrics.get("epoch"),
+            "best_macro_f1": best_metrics.get("macro_f1"),
+            "test_accuracy": test_metrics.get("accuracy"),
+            "test_macro_f1": test_metrics.get("macro_f1"),
+            "test_weighted_f1": test_metrics.get("weighted_f1"),
+            "test_balanced_accuracy": test_metrics.get("balanced_accuracy"),
+            "test_mcc": test_metrics.get("mcc"),
+            "test_macro_precision": test_metrics.get("macro_precision"),
+            "test_macro_recall": test_metrics.get("macro_recall"),
+        }
+        rows.append(row)
+
+    df = pd.DataFrame(rows)
+
+    # Sort by split_type, then seed
+    if not df.empty:
+        df = df.sort_values(["split_type", "seed", "model_name"]).reset_index(drop=True)
+
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+def generate_comparison_report(df: pd.DataFrame, output_dir: Path) -> None:
+    """Write benchmark results as JSON, CSV, and human-readable summary."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # CSV
+    csv_path = output_dir / "benchmark_results.csv"
+    df.to_csv(csv_path, index=False)
+    print(f"[BENCHMARK] Results CSV: {csv_path}")
+
+    # JSON
+    json_path = output_dir / "benchmark_results.json"
+    records = df.to_dict(orient="records")
+    with open(json_path, "w") as f:
+        json.dump(
+            {
+                "generated_at": _dt.datetime.now().isoformat(),
+                "num_runs": len(records),
+                "results": records,
+            },
+            f,
+            indent=2,
+            ensure_ascii=False,
+            default=str,
+        )
+    print(f"[BENCHMARK] Results JSON: {json_path}")
+
+    # Human-readable summary
+    summary_path = output_dir / "benchmark_summary.txt"
+    with open(summary_path, "w") as f:
+        f.write("=" * 70 + "\n")
+        f.write("CFRP GNN Benchmark Summary\n")
+        f.write(f"Generated: {_dt.datetime.now().isoformat()}\n")
+        f.write(f"Total runs: {len(df)}\n")
+        f.write("=" * 70 + "\n\n")
+
+        if df.empty:
+            f.write("No results to report.\n")
+        else:
+            # Per split-type summary
+            numeric_cols = ["test_macro_f1", "test_weighted_f1", "test_balanced_accuracy", "test_mcc"]
+            for split_type in df["split_type"].unique():
+                subset = df[df["split_type"] == split_type]
+                f.write(f"\n--- Split: {split_type} ({len(subset)} runs) ---\n")
+
+                for col in numeric_cols:
+                    vals = subset[col].dropna()
+                    if len(vals) > 0:
+                        f.write(f"  {col}: mean={vals.mean():.4f}, std={vals.std():.4f}, "
+                                f"min={vals.min():.4f}, max={vals.max():.4f}\n")
+
+            f.write("\n\n--- Full Results Table ---\n")
+            f.write(df.to_string(index=False))
+            f.write("\n")
+
+    print(f"[BENCHMARK] Summary: {summary_path}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reproducible benchmark runner for CFRP GNN",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--config", type=str, default=None,
+                        help="Path to benchmark YAML config file")
+    parser.add_argument("--split_types", nargs="+", default=None,
+                        help="Override split types (e.g., iid defect_size layer)")
+    parser.add_argument("--seeds", nargs="+", type=int, default=None,
+                        help="Override seeds (e.g., 42 84 126)")
+    parser.add_argument("--epochs", type=int, default=None,
+                        help="Override epoch count")
+    parser.add_argument("--output_dir", type=str, default=None,
+                        help="Output directory for benchmark results")
+    parser.add_argument("--collect_only", action="store_true",
+                        help="Skip training, just collect metrics from existing runs")
+    parser.add_argument("--run_dirs", nargs="+", default=None,
+                        help="Explicit run directories for --collect_only mode")
+    parser.add_argument("--dry_run", action="store_true",
+                        help="Print commands without executing training")
+    parser.add_argument("--nproc_per_node", type=int, default=None,
+                        help="Override GPU count")
+    args = parser.parse_args()
+
+    # Load config
+    config = load_benchmark_config(args.config)
+
+    # CLI overrides
+    if args.split_types:
+        config["split_types"] = [{"type": st} for st in args.split_types]
+    if args.seeds:
+        config["seeds"] = args.seeds
+    if args.epochs:
+        for model in config.get("models", []):
+            model.setdefault("args", {})["epochs"] = args.epochs
+    if args.nproc_per_node:
+        config.setdefault("hardware", {})["nproc_per_node"] = args.nproc_per_node
+
+    # Output directory
+    ts = _dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_base_name = config.get("output", {}).get("base_dir", "runs")
+    output_base = Path(args.output_dir) if args.output_dir else REPO_ROOT / output_base_name / f"benchmark_{ts}"
+    output_base.mkdir(parents=True, exist_ok=True)
+
+    # Save config used
+    config_out = output_base / "benchmark_config_used.json"
+    with open(config_out, "w") as f:
+        json.dump(config, f, indent=2, ensure_ascii=False, default=str)
+
+    if args.collect_only:
+        # Collect-only mode
+        if not args.run_dirs:
+            print("[ERROR] --collect_only requires --run_dirs")
+            return 1
+
+        all_results = []
+        for rd in args.run_dirs:
+            run_dir = Path(rd)
+            if not run_dir.exists():
+                print(f"[WARN] Run dir not found: {run_dir}")
+                continue
+            metrics = collect_run_metrics(run_dir)
+            # Try to infer run info from run_id
+            run_id = run_dir.name
+            all_results.append({
+                "run_info": {"run_id": run_id},
+                "metrics": metrics,
+            })
+
+        df = aggregate_results(all_results)
+        generate_comparison_report(df, output_base)
+        return 0
+
+    # Generate and execute run matrix
+    matrix = generate_run_matrix(config)
+
+    print(f"\n[BENCHMARK] Configuration: {config.get('name', 'unnamed')}")
+    print(f"[BENCHMARK] Total runs planned: {len(matrix)}")
+    print(f"[BENCHMARK] Output directory: {output_base}")
+    for i, spec in enumerate(matrix):
+        print(f"  [{i+1}] {spec['run_id']} (split={spec['split_type']}, seed={spec['seed']})")
+    print()
+
+    # Execute runs
+    all_results = []
+    for i, run_spec in enumerate(matrix):
+        print(f"\n[BENCHMARK] Run {i+1}/{len(matrix)}")
+        run_result = execute_single_run(
+            run_spec=run_spec,
+            config=config,
+            output_base=output_base,
+            dry_run=args.dry_run,
+        )
+
+        if args.dry_run:
+            all_results.append({"run_info": run_spec, "metrics": {}})
+            continue
+
+        # Collect metrics from completed run
+        run_dir = Path(run_result.get("run_dir", ""))
+        if run_dir.exists():
+            metrics = collect_run_metrics(run_dir)
+        else:
+            metrics = {}
+
+        all_results.append({
+            "run_info": {**run_spec, **run_result},
+            "metrics": metrics,
+        })
+
+    # Aggregate and report
+    if not args.dry_run:
+        df = aggregate_results(all_results)
+        generate_comparison_report(df, output_base)
+    else:
+        print(f"\n[DRY RUN] Would write results to: {output_base}")
+
+    print(f"\n[BENCHMARK] Done. Output: {output_base}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/benchmark_config.yaml
+++ b/tools/benchmark_config.yaml
@@ -1,0 +1,61 @@
+# Benchmark configuration for CFRP GNN defect localization
+# Usage: python tools/benchmark.py --config tools/benchmark_config.yaml
+
+benchmark:
+  name: "cfrp_gnn_benchmark_v1"
+  description: "CFRP defect localization GNN reproducible benchmark"
+
+  # Fixed seeds for reproducibility (each split_type is run with each seed)
+  seeds: [42, 84, 126]
+
+  # Split strategies to evaluate
+  split_types:
+    - type: "iid"
+    - type: "defect_size"
+      params:
+        size_threshold: 5
+    - type: "layer"
+      params:
+        train_layers: [1, 2, 3, 4, 5]
+
+  # Model configurations to benchmark
+  models:
+    - name: "GAT_base"
+      args:
+        hidden_channels: 16
+        learning_rate: 0.002
+        epochs: 500
+        patience: 100
+        batch_size: 64
+        dropout: 0.10
+        edge_drop: 0.01
+        use_amp: true
+        use_class_frequency_sampler: true
+
+  # Primary and secondary metrics for comparison
+  metrics:
+    primary: "macro_f1"
+    secondary:
+      - "weighted_f1"
+      - "balanced_accuracy"
+      - "mcc"
+      - "top_1_accuracy"
+      - "top_3_accuracy"
+      - "top_5_accuracy"
+      - "mean_distance_error"
+      - "auprc"
+
+  # Hardware settings
+  hardware:
+    nproc_per_node: 4
+
+  # Data paths (relative to project root)
+  data:
+    data_dir: "GNN_hole_2026/all_sub_hole_defect_zscore"
+    label_dir: "GNN_hole_2026/all_19class_label"
+    num_classes: 19
+
+  # Output
+  output:
+    base_dir: "runs"
+    prefix: "bench"

--- a/tools/package_sample_dataset.py
+++ b/tools/package_sample_dataset.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""
+Create a small, shareable sample dataset from the full CFRP GNN dataset.
+
+Selects a stratified sample covering all defect sizes and multiple layers,
+then packages it with metadata and a standalone loader.
+
+Usage:
+    python tools/package_sample_dataset.py \
+        --data_dir GNN_hole_2026/all_sub_hole_defect_zscore \
+        --label_dir GNN_hole_2026/all_19class_label \
+        --output_dir sample_dataset \
+        --n_per_size 5 \
+        --n_per_layer 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import re
+import shutil
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Filename parsing patterns
+RE_DEFECT = re.compile(
+    r"Defect_L(\d+)_B(\d+)_el(\d+)_H(\d+)_W(\d+)"
+)
+RE_NOISE_FREE = re.compile(r"NoiseDefectFree_")
+
+
+def parse_filename(fname: str) -> Dict[str, any]:
+    """Extract metadata from a data filename."""
+    m = RE_DEFECT.match(fname)
+    if m:
+        h, w = int(m.group(4)), int(m.group(5))
+        if h <= 2 and w <= 2:
+            size_class = "small"
+        elif h <= 4 and w <= 4:
+            size_class = "medium"
+        else:
+            size_class = "large"
+        return {
+            "type": "defect",
+            "layer": int(m.group(1)),
+            "block": int(m.group(2)),
+            "element": int(m.group(3)),
+            "h": h,
+            "w": w,
+            "size_class": size_class,
+        }
+    if RE_NOISE_FREE.match(fname):
+        return {"type": "noise_defect_free"}
+    return {"type": "unknown"}
+
+
+def select_sample_subset(
+    data_dir: str,
+    label_dir: str,
+    n_per_size: int = 5,
+    n_per_layer: int = 3,
+    n_defect_free: int = 5,
+    seed: int = 42,
+) -> List[Tuple[str, str, str]]:
+    """Select a stratified sample covering all defect sizes and layers.
+
+    Returns list of (data_filename, label_filename, source_dir).
+    """
+    rng = np.random.RandomState(seed)
+
+    # Collect all data files with labels
+    data_path = Path(data_dir)
+    label_path = Path(label_dir)
+
+    all_files: List[Tuple[str, str, str]] = []
+    # Handle subdirectory structure
+    subdirs = [d for d in data_path.iterdir() if d.is_dir()]
+    if subdirs:
+        dirs_to_scan = subdirs
+    else:
+        dirs_to_scan = [data_path]
+
+    for scan_dir in dirs_to_scan:
+        for f in scan_dir.iterdir():
+            if not f.suffix == ".npy":
+                continue
+            base = f.stem
+            label_fname = f"{base}_19label.npy"
+            if (label_path / label_fname).exists():
+                all_files.append((f.name, label_fname, str(scan_dir)))
+
+    # Group by (size_class, layer)
+    by_size: Dict[str, List] = defaultdict(list)
+    defect_free: List = []
+
+    for data_f, label_f, src_dir in all_files:
+        meta = parse_filename(data_f)
+        if meta["type"] == "defect":
+            key = meta["size_class"]
+            by_size[key].append((data_f, label_f, src_dir, meta))
+        elif meta["type"] == "noise_defect_free":
+            defect_free.append((data_f, label_f, src_dir))
+
+    selected = []
+
+    # Select per size class, stratified by layer
+    for size_class in ["small", "medium", "large"]:
+        candidates = by_size.get(size_class, [])
+        if not candidates:
+            print(f"[WARN] No candidates for size_class={size_class}")
+            continue
+
+        # Group by layer within this size class
+        by_layer: Dict[int, List] = defaultdict(list)
+        for item in candidates:
+            by_layer[item[3]["layer"]].append(item)
+
+        # Select n_per_layer from each layer, up to n_per_size total
+        layer_selections = []
+        layers = sorted(by_layer.keys())
+        for layer in layers:
+            layer_cands = by_layer[layer]
+            n = min(n_per_layer, len(layer_cands))
+            indices = rng.choice(len(layer_cands), size=n, replace=False)
+            for idx in indices:
+                layer_selections.append(layer_cands[idx])
+
+        # Cap at n_per_size
+        if len(layer_selections) > n_per_size:
+            indices = rng.choice(len(layer_selections), size=n_per_size, replace=False)
+            layer_selections = [layer_selections[i] for i in sorted(indices)]
+
+        for item in layer_selections:
+            selected.append((item[0], item[1], item[2]))
+
+    # Add defect-free samples
+    if defect_free:
+        n = min(n_defect_free, len(defect_free))
+        indices = rng.choice(len(defect_free), size=n, replace=False)
+        for idx in indices:
+            selected.append(defect_free[idx])
+
+    print(f"[INFO] Selected {len(selected)} samples for packaging")
+    return selected
+
+
+def package_dataset(
+    selected: List[Tuple[str, str, str]],
+    label_dir: str,
+    output_dir: str,
+) -> None:
+    """Copy selected files to output directory with proper structure."""
+    out = Path(output_dir)
+    data_out = out / "data"
+    label_out = out / "labels"
+    data_out.mkdir(parents=True, exist_ok=True)
+    label_out.mkdir(parents=True, exist_ok=True)
+
+    for data_f, label_f, src_dir in selected:
+        # Copy data file
+        src_data = Path(src_dir) / data_f
+        if src_data.exists():
+            shutil.copy2(src_data, data_out / data_f)
+
+        # Copy label file
+        src_label = Path(label_dir) / label_f
+        if src_label.exists():
+            shutil.copy2(src_label, label_out / label_f)
+
+    print(f"[INFO] Copied {len(selected)} data + label files to {out}")
+
+
+def generate_metadata(
+    selected: List[Tuple[str, str, str]],
+    output_dir: str,
+) -> None:
+    """Write metadata.json describing the sample dataset."""
+    out = Path(output_dir)
+
+    # Analyze selected files
+    size_counts = defaultdict(int)
+    layer_counts = defaultdict(int)
+    types = defaultdict(int)
+
+    for data_f, _, _ in selected:
+        meta = parse_filename(data_f)
+        types[meta["type"]] += 1
+        if meta["type"] == "defect":
+            size_counts[meta["size_class"]] += 1
+            layer_counts[meta["layer"]] += 1
+
+    # Try to get node count from first file
+    sample_data_path = out / "data" / selected[0][0] if selected else None
+    num_nodes = None
+    if sample_data_path and sample_data_path.exists():
+        arr = np.load(sample_data_path)
+        num_nodes = len(arr) if arr.ndim == 1 else arr.shape[0]
+
+    metadata = {
+        "dataset_name": "CFRP GNN Sample Dataset",
+        "version": "1.0",
+        "created_at": _dt.datetime.now().isoformat(),
+        "description": "Sample subset of CFRP defect localization dataset for GNN benchmarking",
+        "num_samples": len(selected),
+        "num_nodes_per_sample": num_nodes,
+        "num_features": 4,
+        "feature_names": ["x_coord", "y_coord", "z_coord", "DSPSS"],
+        "num_classes": 19,
+        "label_format": "one-hot encoded [N, 19]",
+        "defect_size_distribution": dict(size_counts),
+        "layer_distribution": {str(k): v for k, v in sorted(layer_counts.items())},
+        "sample_type_counts": dict(types),
+        "file_naming_convention": "Defect_L{layer}_B{block}_el{element}_H{height}_W{width}.npy",
+        "label_naming_convention": "{basename}_19label.npy",
+    }
+
+    meta_path = out / "metadata.json"
+    with open(meta_path, "w") as f:
+        json.dump(metadata, f, indent=2, ensure_ascii=False)
+
+    print(f"[INFO] Metadata written to {meta_path}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Package a sample CFRP GNN dataset")
+    parser.add_argument("--data_dir", type=str,
+                        default="GNN_hole_2026/all_sub_hole_defect_zscore",
+                        help="Data directory (relative to project root)")
+    parser.add_argument("--label_dir", type=str,
+                        default="GNN_hole_2026/all_19class_label",
+                        help="Label directory (relative to project root)")
+    parser.add_argument("--output_dir", type=str, default="sample_dataset",
+                        help="Output directory for the sample dataset")
+    parser.add_argument("--n_per_size", type=int, default=5,
+                        help="Number of samples per defect size class")
+    parser.add_argument("--n_per_layer", type=int, default=3,
+                        help="Number of samples per layer within each size class")
+    parser.add_argument("--n_defect_free", type=int, default=5,
+                        help="Number of defect-free samples to include")
+    parser.add_argument("--seed", type=int, default=42,
+                        help="Random seed for reproducible selection")
+    args = parser.parse_args()
+
+    data_dir = str(REPO_ROOT / args.data_dir)
+    label_dir = str(REPO_ROOT / args.label_dir)
+    output_dir = str(REPO_ROOT / args.output_dir)
+
+    selected = select_sample_subset(
+        data_dir=data_dir,
+        label_dir=label_dir,
+        n_per_size=args.n_per_size,
+        n_per_layer=args.n_per_layer,
+        n_defect_free=args.n_defect_free,
+        seed=args.seed,
+    )
+
+    package_dataset(selected, label_dir, output_dir)
+    generate_metadata(selected, output_dir)
+
+    print(f"\n[DONE] Sample dataset packaged at: {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sample_data_loader.py
+++ b/tools/sample_data_loader.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Standalone data loader for the CFRP GNN sample dataset.
+
+This module is self-contained — it has no dependency on the full GNN project.
+It only requires numpy and torch_geometric (PyG).
+
+Usage:
+    from sample_data_loader import CFRPSampleDataset
+
+    dataset = CFRPSampleDataset("sample_dataset")
+    print(f"Number of samples: {len(dataset)}")
+    data = dataset[0]
+    print(f"Nodes: {data.num_nodes}, Features: {data.x.shape[1]}, Classes: {data.y.max()+1}")
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+
+try:
+    import torch
+    from torch_geometric.data import Data, Dataset
+    HAS_PYG = True
+except ImportError:
+    HAS_PYG = False
+    Data = None
+    Dataset = object
+
+
+class CFRPSampleDataset(Dataset if HAS_PYG else object):
+    """PyG-compatible dataset loader for the CFRP GNN sample dataset.
+
+    Args:
+        root_dir: Path to the sample dataset directory (containing data/, labels/, metadata.json)
+        transform: Optional PyG transform
+        pre_transform: Optional PyG pre-transform
+    """
+
+    def __init__(
+        self,
+        root_dir: str,
+        transform=None,
+        pre_transform=None,
+    ):
+        self.root_dir = Path(root_dir)
+        self.data_dir = self.root_dir / "data"
+        self.label_dir = self.root_dir / "labels"
+        self.metadata = self._load_metadata()
+
+        # Build file list
+        self._data_files = sorted(
+            f.name for f in self.data_dir.iterdir()
+            if f.suffix == ".npy" and not f.name.endswith("_19label.npy")
+        )
+
+        if HAS_PYG:
+            super().__init__(str(self.root_dir), transform, pre_transform)
+
+    def _load_metadata(self) -> dict:
+        meta_path = self.root_dir / "metadata.json"
+        if meta_path.exists():
+            with open(meta_path) as f:
+                return json.load(f)
+        return {}
+
+    def len(self) -> int:
+        return len(self._data_files)
+
+    def __len__(self) -> int:
+        return self.len()
+
+    def get(self, idx: int):
+        return self._load_sample(idx)
+
+    def __getitem__(self, idx: int):
+        return self.get(idx)
+
+    def _load_sample(self, idx: int):
+        """Load a single sample as a PyG Data object."""
+        if not HAS_PYG:
+            raise ImportError(
+                "torch and torch_geometric are required. "
+                "Install with: pip install torch torch_geometric"
+            )
+
+        data_fname = self._data_files[idx]
+        base = os.path.splitext(data_fname)[0]
+        label_fname = f"{base}_19label.npy"
+
+        # Load features
+        features = np.load(self.data_dir / data_fname)
+        num_nodes = self.metadata.get("num_nodes_per_sample")
+        num_features = self.metadata.get("num_features", 4)
+
+        if features.ndim == 1 and num_nodes:
+            # Stacked 1D array → reshape to [N, F]
+            features = features.reshape(num_features, num_nodes).T
+        elif features.ndim == 1:
+            # Try to infer shape
+            if len(features) % 4 == 0:
+                n = len(features) // 4
+                features = features.reshape(4, n).T
+            else:
+                features = features.reshape(-1, 1)
+
+        x = torch.tensor(features, dtype=torch.float)
+
+        # Load labels
+        label_path = self.label_dir / label_fname
+        if label_path.exists():
+            labels = np.load(label_path)
+            if labels.ndim == 2:
+                # One-hot → class indices
+                y = torch.tensor(labels.argmax(axis=1), dtype=torch.long)
+            else:
+                y = torch.tensor(labels, dtype=torch.long)
+        else:
+            # Defect-free: all class 0
+            y = torch.zeros(x.shape[0], dtype=torch.long)
+
+        data = Data(x=x, y=y)
+        data.filename = data_fname
+        return data
+
+    @staticmethod
+    def load_all(root_dir: str) -> List:
+        """Convenience method to load all samples as a list of PyG Data objects."""
+        dataset = CFRPSampleDataset(root_dir)
+        return [dataset[i] for i in range(len(dataset))]
+
+    def summary(self) -> str:
+        """Return a human-readable summary of the dataset."""
+        lines = [
+            f"CFRPSampleDataset: {self.root_dir}",
+            f"  Samples: {len(self)}",
+            f"  Metadata: {self.metadata.get('description', 'N/A')}",
+        ]
+        if self.metadata.get("num_nodes_per_sample"):
+            lines.append(f"  Nodes/sample: {self.metadata['num_nodes_per_sample']}")
+        if self.metadata.get("defect_size_distribution"):
+            lines.append(f"  Size dist: {self.metadata['defect_size_distribution']}")
+        return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    import sys
+    root = sys.argv[1] if len(sys.argv) > 1 else "sample_dataset"
+    ds = CFRPSampleDataset(root)
+    print(ds.summary())
+    if len(ds) > 0:
+        sample = ds[0]
+        print(f"\nSample 0: x={sample.x.shape}, y={sample.y.shape}, file={sample.filename}")


### PR DESCRIPTION
## Summary
- Add reproducible benchmark runner (`tools/benchmark.py`) orchestrating (split_type × seed) training matrix via `launch_run.py`
- Add `--split_manifest` support to training script for externally controlled data splits
- Add `compute_benchmark_metrics()` to `gnn_common/metrics.py` for standardized metric computation
- Add sample dataset packager and standalone PyG data loader for external sharing

## Key Design
- **Wraps existing infrastructure**: delegates to `launch_run.py` (no refactoring of the 238KB training script)
- **Split manifest JSON**: benchmark runner computes splits via `create_ood_split()`, writes manifest, passes `--split_manifest` to training script
- Supports `--dry_run`, `--collect_only`, CLI overrides for split types / seeds / epochs

## Files Changed
| File | Change |
|------|--------|
| `gnn_common/metrics.py` | Add `compute_benchmark_metrics()` |
| `GNN_hole_2026/.../GNN_zscore_sub_noise_defect_free.py` | Add `--split_manifest` argument (~20 lines) |
| `tools/benchmark.py` | **New**: benchmark runner |
| `tools/benchmark_config.yaml` | **New**: default config (3 seeds × 3 splits × GAT base) |
| `tools/package_sample_dataset.py` | **New**: stratified sample dataset packager |
| `tools/sample_data_loader.py` | **New**: standalone PyG Dataset loader |
| `tests/test_benchmark.py` | **New**: 17 unit tests |

## Test plan
- [x] `python -m unittest tests.test_benchmark -v` — 17 tests pass
- [x] `python tools/benchmark.py --dry_run --split_types iid --seeds 42 --epochs 5` — dry run verified
- [ ] Full benchmark run with `--config tools/benchmark_config.yaml`
- [ ] `python tools/package_sample_dataset.py --n_per_size 2` — sample dataset creation

## Wiki
- [Benchmark Suite (Issue #5)](https://github.com/keisuke58/nishioka_cfrp_gnn/wiki/Benchmark-Suite-(Issue-%235))

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)