### PR TITLE
feat: Optuna HPO & fine-tuning comparison (Issue #4)

### DIFF
--- a/tests/test_hpo.py
+++ b/tests/test_hpo.py
@@ -1,0 +1,241 @@
+"""HPO and fine-tuning comparison unit tests."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import optuna
+import pandas as pd
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools.optuna_hpo import (
+    load_hpo_config,
+    sample_hyperparams,
+    sample_finetune_params,
+    build_training_args,
+    create_study,
+    export_results,
+)
+from tools.finetune_comparison import load_finetune_config, DEFAULT_STRATEGIES
+from tools.analyze_sweeps import load_optuna_study
+
+
+class TestHPOConfig(unittest.TestCase):
+    """Test HPO config loading."""
+
+    def test_default_config(self):
+        cfg = load_hpo_config(None)
+        self.assertIn("study_name", cfg)
+        self.assertIn("search_space", cfg)
+        self.assertIn("fixed_params", cfg)
+        self.assertIsInstance(cfg["search_space"], dict)
+
+    def test_yaml_config(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("hpo:\n  study_name: test_study\n  n_trials: 5\n")
+            f.flush()
+            cfg = load_hpo_config(f.name)
+
+        self.assertEqual(cfg["study_name"], "test_study")
+        self.assertEqual(cfg["n_trials"], 5)
+        # defaults should be filled in
+        self.assertIn("search_space", cfg)
+        Path(f.name).unlink()
+
+    def test_missing_config(self):
+        cfg = load_hpo_config("/nonexistent.yaml")
+        self.assertIn("study_name", cfg)
+
+
+class TestSearchSpace(unittest.TestCase):
+    """Test hyperparameter sampling."""
+
+    def test_sample_hyperparams(self):
+        study = optuna.create_study(direction="maximize")
+        trial = study.ask()
+
+        search_space = {
+            "lr": {"type": "log_float", "low": 1e-4, "high": 1e-2},
+            "batch": {"type": "categorical", "choices": [32, 64]},
+            "drop": {"type": "float", "low": 0.0, "high": 0.5},
+        }
+        params = sample_hyperparams(trial, search_space)
+
+        self.assertIn("lr", params)
+        self.assertIn("batch", params)
+        self.assertIn("drop", params)
+        self.assertGreater(params["lr"], 0)
+        self.assertIn(params["batch"], [32, 64])
+        self.assertGreaterEqual(params["drop"], 0.0)
+        self.assertLessEqual(params["drop"], 0.5)
+
+    def test_sample_finetune_params(self):
+        study = optuna.create_study(direction="maximize")
+        trial = study.ask()
+
+        params = sample_finetune_params(trial)
+        self.assertIn("epochs", params)
+        self.assertIn("patience", params)
+        # Should have at least one strategy-specific param
+        has_strategy_param = (
+            "freeze_backbone" in params
+            or "backbone_lr" in params
+            or "learning_rate" in params
+        )
+        self.assertTrue(has_strategy_param)
+
+
+class TestBuildTrainingArgs(unittest.TestCase):
+    """Test training args construction."""
+
+    def test_basic_args(self):
+        params = {"learning_rate": 0.001, "batch_size": 64}
+        fixed = {"epochs": 100, "use_amp": True}
+        args = build_training_args(params, fixed)
+
+        self.assertIn("--", args)
+        self.assertIn("--learning_rate", args)
+        self.assertIn("0.001", args)
+        self.assertIn("--use_amp", args)
+
+    def test_bool_false_excluded(self):
+        params = {"use_logit_adjust": False}
+        args = build_training_args(params, {})
+        self.assertNotIn("--use_logit_adjust", args)
+
+    def test_bool_true_included(self):
+        params = {"use_amp": True}
+        args = build_training_args(params, {})
+        self.assertIn("--use_amp", args)
+
+
+class TestStudyCreation(unittest.TestCase):
+    """Test Optuna study creation."""
+
+    def test_create_study_sqlite(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = {
+                "study_name": "test_create",
+                "direction": "maximize",
+                "pruner": {"type": "median", "n_startup_trials": 3, "n_warmup_steps": 10},
+                "sampler": {"type": "tpe", "seed": 42},
+                "output": {"study_db_dir": tmp},
+            }
+            study = create_study(config)
+            self.assertEqual(study.study_name, "test_create")
+            self.assertTrue((Path(tmp) / "test_create.db").exists())
+
+    def test_resume_study(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = {
+                "study_name": "test_resume",
+                "direction": "maximize",
+                "pruner": {"type": "nop"},
+                "sampler": {"type": "random", "seed": 0},
+                "output": {"study_db_dir": tmp},
+            }
+            # Create and add a trial
+            study1 = create_study(config)
+            study1.add_trial(
+                optuna.trial.create_trial(
+                    params={"lr": 0.001},
+                    distributions={"lr": optuna.distributions.FloatDistribution(1e-4, 1e-2)},
+                    values=[0.7],
+                )
+            )
+            self.assertEqual(len(study1.trials), 1)
+
+            # Resume
+            study2 = create_study(config)
+            self.assertEqual(len(study2.trials), 1)
+
+
+class TestExportResults(unittest.TestCase):
+    """Test result export."""
+
+    def test_export_with_trials(self):
+        study = optuna.create_study(study_name="test_export", direction="maximize")
+        for i in range(5):
+            study.add_trial(
+                optuna.trial.create_trial(
+                    params={"lr": 0.001 * (i + 1), "batch": 64},
+                    distributions={
+                        "lr": optuna.distributions.FloatDistribution(1e-4, 1e-2),
+                        "batch": optuna.distributions.CategoricalDistribution([32, 64]),
+                    },
+                    values=[0.6 + i * 0.02],
+                )
+            )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            export_results(study, Path(tmp))
+            self.assertTrue((Path(tmp) / "hpo_trials.csv").exists())
+            self.assertTrue((Path(tmp) / "hpo_summary.json").exists())
+            self.assertTrue((Path(tmp) / "hpo_summary.txt").exists())
+
+            with open(Path(tmp) / "hpo_summary.json") as f:
+                summary = json.load(f)
+            self.assertEqual(summary["n_trials"], 5)
+            self.assertIsNotNone(summary["best_trial"])
+
+    def test_export_empty_study(self):
+        study = optuna.create_study(study_name="test_empty", direction="maximize")
+        with tempfile.TemporaryDirectory() as tmp:
+            export_results(study, Path(tmp))
+            self.assertTrue((Path(tmp) / "hpo_summary.json").exists())
+
+
+class TestFinetuneConfig(unittest.TestCase):
+    """Test fine-tuning comparison config."""
+
+    def test_default_strategies(self):
+        cfg = load_finetune_config(None)
+        strategies = cfg["strategies"]
+        self.assertEqual(len(strategies), 3)
+        names = [s["name"] for s in strategies]
+        self.assertIn("freeze_backbone", names)
+        self.assertIn("differential_lr", names)
+        self.assertIn("higher_lr", names)
+
+    def test_default_seeds(self):
+        cfg = load_finetune_config(None)
+        self.assertEqual(cfg["seeds"], [42, 84, 126])
+
+
+class TestOptunaStudyLoader(unittest.TestCase):
+    """Test loading Optuna study for analyze_sweeps integration."""
+
+    def test_load_study_db(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "test.db"
+            storage = f"sqlite:///{db_path}"
+
+            study = optuna.create_study(
+                study_name="loader_test",
+                storage=storage,
+                direction="maximize",
+            )
+            study.add_trial(
+                optuna.trial.create_trial(
+                    params={"lr": 0.002, "batch": 64},
+                    distributions={
+                        "lr": optuna.distributions.FloatDistribution(1e-4, 1e-2),
+                        "batch": optuna.distributions.CategoricalDistribution([32, 64]),
+                    },
+                    values=[0.73],
+                )
+            )
+
+            df = load_optuna_study(str(db_path))
+            self.assertGreater(len(df), 0)
+            self.assertIn("best_macro_f1", df.columns)
+            self.assertAlmostEqual(df.iloc[0]["best_macro_f1"], 0.73)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/analyze_sweeps.py
+++ b/tools/analyze_sweeps.py
@@ -13,6 +13,7 @@ import argparse
 import csv
 import json
 from pathlib import Path
+from typing import Optional
 from typing import Any, Dict, List, Optional
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -178,15 +179,86 @@ def generate_summary_report(df: pd.DataFrame, best_model: Dict[str, Any], output
     print(f"[INFO] Saved: {txt_path}")
 
 
+def load_optuna_study(study_db_path: str, study_name: Optional[str] = None) -> pd.DataFrame:
+    """Load trials from an Optuna SQLite study database as a DataFrame.
+
+    Args:
+        study_db_path: Path to the .db file (SQLite)
+        study_name: Study name (if None, uses the first study found)
+
+    Returns:
+        DataFrame with columns similar to sweep CSVs for unified analysis
+    """
+    try:
+        import optuna
+    except ImportError:
+        print("[ERR] optuna is required for --optuna_db. pip install optuna")
+        return pd.DataFrame()
+
+    storage = f"sqlite:///{Path(study_db_path).resolve()}"
+    studies = optuna.study.get_all_study_summaries(storage)
+    if not studies:
+        print(f"[WARN] No studies found in {study_db_path}")
+        return pd.DataFrame()
+
+    if study_name is None:
+        study_name = studies[0].study_name
+        print(f"[INFO] Using study: {study_name}")
+
+    study = optuna.load_study(study_name=study_name, storage=storage)
+    df = study.trials_dataframe()
+
+    if df.empty:
+        return df
+
+    # Rename columns to match sweep CSV format for unified analysis
+    rename_map = {}
+    for col in df.columns:
+        if col.startswith("params_"):
+            rename_map[col] = col.replace("params_", "")
+    df = df.rename(columns=rename_map)
+
+    if "value" in df.columns:
+        df["best_macro_f1"] = df["value"]
+    if "number" in df.columns:
+        df["run_id"] = df["number"].apply(lambda n: f"trial_{n:03d}")
+
+    return df
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Analyze hyperparameter sweep results")
     parser.add_argument('--sweep_csv', type=str, nargs='+', help='Path(s) to sweep CSV file(s)')
     parser.add_argument('--sweep_dir', type=str, help='Directory containing sweep CSV files')
+    parser.add_argument('--optuna_db', type=str, help='Path to Optuna SQLite study database (.db)')
+    parser.add_argument('--study_name', type=str, default=None, help='Optuna study name (default: first)')
     parser.add_argument('--output_dir', type=str, default='reports', help='Output directory for reports')
     parser.add_argument('--pattern', type=str, default='sweep_*.csv', help='File pattern for sweep CSVs')
-    
+
     args = parser.parse_args()
     
+    # Optuna DB mode
+    if args.optuna_db:
+        db_path = Path(args.optuna_db).expanduser().resolve()
+        if not db_path.exists():
+            print(f"[ERR] Optuna DB not found: {db_path}")
+            return 1
+        combined_df = load_optuna_study(str(db_path), args.study_name)
+        if combined_df.empty:
+            print("[ERR] No trials found in Optuna study")
+            return 1
+        print(f"[INFO] Loaded {len(combined_df)} trials from Optuna study")
+        output_dir = Path(args.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        best_model = find_best_model(combined_df)
+        if best_model:
+            print(f"[INFO] Best model: {best_model['run_id']} (F1: {best_model.get('best_macro_f1', 'N/A')})")
+        plot_learning_rate_comparison(combined_df, output_dir)
+        plot_hyperparameter_heatmap(combined_df, output_dir)
+        generate_summary_report(combined_df, best_model, output_dir)
+        print(f"[INFO] Analysis complete. Output directory: {output_dir}")
+        return 0
+
     # Collect CSV files
     csv_files: List[Path] = []
     if args.sweep_csv:
@@ -201,7 +273,7 @@ def main() -> int:
         sweep_dir = Path(args.sweep_dir)
         csv_files = list(sweep_dir.glob(args.pattern))
     else:
-        parser.error("Either --sweep_csv or --sweep_dir must be provided")
+        parser.error("Either --sweep_csv, --sweep_dir, or --optuna_db must be provided")
     
     if not csv_files:
         print("[ERR] No CSV files found")

--- a/tools/finetune_comparison.py
+++ b/tools/finetune_comparison.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Fine-tuning strategy comparison for CFRP GNN.
+
+Runs 3 strategies (freeze_backbone, differential_lr, higher_lr) × N seeds,
+collects metrics, and produces a comparison table.
+
+Usage:
+    python tools/finetune_comparison.py \
+        --pretrained_from runs/.../best_model.pth \
+        --seeds 42 84 126
+
+    python tools/finetune_comparison.py --pretrained_from runs/.../best_model.pth --dry_run
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.compare_runs import load_run_metrics
+from tools.benchmark import aggregate_results, generate_comparison_report
+
+# Default fine-tuning strategies
+DEFAULT_STRATEGIES = [
+    {
+        "name": "freeze_backbone",
+        "args": {
+            "freeze_backbone": True,
+            "head_lr": 0.001,
+            "epochs": 500,
+            "patience": 150,
+            "use_amp": True,
+            "use_class_frequency_sampler": True,
+        },
+    },
+    {
+        "name": "differential_lr",
+        "args": {
+            "backbone_lr": 0.0001,
+            "head_lr": 0.001,
+            "learning_rate": 0.001,
+            "epochs": 1000,
+            "patience": 200,
+            "use_amp": True,
+            "use_class_frequency_sampler": True,
+        },
+    },
+    {
+        "name": "higher_lr",
+        "args": {
+            "learning_rate": 0.0005,
+            "epochs": 1000,
+            "patience": 200,
+            "use_amp": True,
+            "use_class_frequency_sampler": True,
+        },
+    },
+]
+
+
+def load_finetune_config(config_path: Optional[str] = None) -> Dict[str, Any]:
+    """Load fine-tune comparison config from YAML."""
+    if config_path:
+        path = Path(config_path)
+        if path.exists():
+            with open(path) as f:
+                raw = yaml.safe_load(f)
+            return raw.get("finetune", raw)
+
+    return {
+        "strategies": DEFAULT_STRATEGIES,
+        "seeds": [42, 84, 126],
+    }
+
+
+def execute_finetune_run(
+    strategy: Dict[str, Any],
+    seed: int,
+    pretrained_from: str,
+    output_base: Path,
+    nproc: int = 4,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Execute a single fine-tuning run."""
+    name = strategy["name"]
+    args = strategy["args"]
+    run_id = f"ft_{name}_s{seed}"
+
+    launcher = str(REPO_ROOT / "tools" / "launch_run.py")
+    cmd = [
+        sys.executable, launcher,
+        "--run_id", run_id,
+        "--output_base", str(output_base),
+        "--nproc_per_node", str(nproc),
+    ]
+    if dry_run:
+        cmd.append("--dry_run")
+
+    # Build training args
+    cmd.append("--")
+    cmd.extend(["--fine_tune_from", pretrained_from])
+
+    for key, val in args.items():
+        arg_key = f"--{key}"
+        if isinstance(val, bool):
+            if val:
+                cmd.append(arg_key)
+        else:
+            cmd.extend([arg_key, str(val)])
+
+    run_dir = output_base / run_id
+
+    print(f"\n{'='*50}")
+    print(f"[FT] {'DRY RUN: ' if dry_run else ''}Strategy: {name}, Seed: {seed}")
+    print(f"  cmd: {' '.join(cmd[:12])}...")
+    print(f"{'='*50}")
+
+    if dry_run:
+        subprocess.run(cmd, cwd=str(REPO_ROOT))
+        return {"run_id": run_id, "status": "dry_run", "strategy": name, "seed": seed}
+
+    result = subprocess.run(cmd, cwd=str(REPO_ROOT))
+    return {
+        "run_id": run_id,
+        "run_dir": str(run_dir),
+        "exit_code": result.returncode,
+        "status": "completed" if result.returncode == 0 else "failed",
+        "strategy": name,
+        "seed": seed,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Fine-tuning strategy comparison")
+    parser.add_argument("--pretrained_from", type=str, required=True,
+                        help="Path to pretrained model")
+    parser.add_argument("--config", type=str, default=None,
+                        help="Config YAML (uses finetune section from hpo_config.yaml)")
+    parser.add_argument("--seeds", nargs="+", type=int, default=None,
+                        help="Override seeds")
+    parser.add_argument("--output_dir", type=str, default=None, help="Output directory")
+    parser.add_argument("--nproc_per_node", type=int, default=4, help="GPUs")
+    parser.add_argument("--dry_run", action="store_true", help="Print commands only")
+    args = parser.parse_args()
+
+    # Validate pretrained model path
+    model_path = Path(args.pretrained_from)
+    if not model_path.exists() and not args.dry_run:
+        print(f"[ERROR] Pretrained model not found: {model_path}")
+        return 1
+
+    config = load_finetune_config(args.config)
+    strategies = config.get("strategies", DEFAULT_STRATEGIES)
+    seeds = args.seeds or config.get("seeds", [42, 84, 126])
+
+    ts = _dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_base = Path(args.output_dir) if args.output_dir else REPO_ROOT / "runs" / f"ft_comparison_{ts}"
+    output_base.mkdir(parents=True, exist_ok=True)
+
+    print(f"[FT] Comparing {len(strategies)} strategies × {len(seeds)} seeds = {len(strategies)*len(seeds)} runs")
+    print(f"[FT] Pretrained from: {args.pretrained_from}")
+    print(f"[FT] Output: {output_base}")
+
+    # Execute all runs
+    all_results = []
+    for strategy in strategies:
+        for seed in seeds:
+            run_result = execute_finetune_run(
+                strategy=strategy,
+                seed=seed,
+                pretrained_from=args.pretrained_from,
+                output_base=output_base,
+                nproc=args.nproc_per_node,
+                dry_run=args.dry_run,
+            )
+
+            if args.dry_run:
+                all_results.append({"run_info": run_result, "metrics": {}})
+                continue
+
+            run_dir = Path(run_result.get("run_dir", ""))
+            metrics = load_run_metrics(run_dir) if run_dir.exists() else {}
+            all_results.append({
+                "run_info": {
+                    "run_id": run_result["run_id"],
+                    "split_type": run_result["strategy"],
+                    "seed": run_result["seed"],
+                    "model_name": run_result["strategy"],
+                },
+                "metrics": metrics,
+            })
+
+    if not args.dry_run:
+        df = aggregate_results(all_results)
+        generate_comparison_report(df, output_base)
+
+        # Additional strategy-level summary
+        if not df.empty and "split_type" in df.columns:
+            print("\n--- Strategy Summary (mean ± std) ---")
+            for strategy in df["split_type"].unique():
+                subset = df[df["split_type"] == strategy]
+                f1_vals = subset["test_macro_f1"].dropna()
+                if len(f1_vals) > 0:
+                    print(f"  {strategy}: test_macro_f1 = {f1_vals.mean():.4f} ± {f1_vals.std():.4f}")
+    else:
+        print(f"\n[DRY RUN] Would run {len(strategies)*len(seeds)} fine-tuning runs")
+
+    print(f"\n[FT] Done. Output: {output_base}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/hpo_config.yaml
+++ b/tools/hpo_config.yaml
@@ -1,0 +1,91 @@
+# Hyperparameter optimization configuration
+# Usage: python tools/optuna_hpo.py --config tools/hpo_config.yaml
+
+hpo:
+  study_name: "cfrp_hpo_v1"
+  n_trials: 20
+  direction: "maximize"
+  metric: "macro_f1"  # key in metrics.json -> best -> macro_f1
+
+  # Optuna pruner (MedianPruner: prune trials performing below median)
+  pruner:
+    type: "median"
+    n_startup_trials: 5     # don't prune first N trials
+    n_warmup_steps: 50      # don't prune before N epochs
+
+  # Optuna sampler
+  sampler:
+    type: "tpe"  # Tree-structured Parzen Estimator
+    seed: 42
+
+  # Search space definition
+  search_space:
+    learning_rate:
+      type: log_float
+      low: 5.0e-4
+      high: 5.0e-3
+    batch_size:
+      type: categorical
+      choices: [32, 64, 128]
+    hidden_channels:
+      type: categorical
+      choices: [16, 32, 64]
+    dropout:
+      type: float
+      low: 0.05
+      high: 0.25
+    gamma:
+      type: float
+      low: 2.0
+      high: 5.0
+    weight_decay:
+      type: log_float
+      low: 1.0e-4
+      high: 1.0e-3
+    edge_drop_prob:
+      type: float
+      low: 0.0
+      high: 0.05
+    use_logit_adjust:
+      type: categorical
+      choices: [true, false]
+
+  # Parameters fixed across all trials
+  fixed_params:
+    epochs: 500
+    patience: 100
+    use_amp: true
+    use_class_frequency_sampler: true
+    data_usage_ratio: 1.0
+
+  # Hardware
+  hardware:
+    nproc_per_node: 4
+
+  # Output
+  output:
+    base_dir: "runs"
+    study_db_dir: "runs/hpo_studies"
+
+# Fine-tuning comparison mode
+finetune:
+  pretrained_from: null  # path to pretrained model (override via CLI)
+  strategies:
+    - name: "freeze_backbone"
+      args:
+        freeze_backbone: true
+        head_lr: 0.001
+        epochs: 500
+        patience: 150
+    - name: "differential_lr"
+      args:
+        backbone_lr: 0.0001
+        head_lr: 0.001
+        epochs: 1000
+        patience: 200
+    - name: "higher_lr"
+      args:
+        learning_rate: 0.0005
+        epochs: 1000
+        patience: 200
+  seeds: [42, 84, 126]

--- a/tools/optuna_hpo.py
+++ b/tools/optuna_hpo.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""
+Optuna-based hyperparameter optimization for CFRP GNN.
+
+Wraps launch_run.py to run training trials with Optuna-sampled hyperparameters.
+Supports SQLite storage for pause/resume and built-in visualization.
+
+Usage:
+    # Basic HPO (20 trials)
+    python tools/optuna_hpo.py --n_trials 20 --study_name cfrp_hpo_v1
+
+    # Quick exploration (reduced epochs)
+    python tools/optuna_hpo.py --n_trials 50 --epochs 200 --patience 50
+
+    # Fine-tuning mode
+    python tools/optuna_hpo.py --mode finetune --pretrained_from runs/.../best.pth
+
+    # Resume existing study
+    python tools/optuna_hpo.py --study_name cfrp_hpo_v1 --n_trials 10
+
+    # Dry run
+    python tools/optuna_hpo.py --n_trials 3 --dry_run
+
+    # Export results from existing study
+    python tools/optuna_hpo.py --export_only --study_name cfrp_hpo_v1
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import optuna
+import pandas as pd
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.compare_runs import load_run_metrics
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def load_hpo_config(config_path: Optional[str] = None) -> Dict[str, Any]:
+    """Load HPO configuration from YAML or return defaults."""
+    defaults = {
+        "study_name": "cfrp_hpo",
+        "n_trials": 20,
+        "direction": "maximize",
+        "metric": "macro_f1",
+        "pruner": {"type": "median", "n_startup_trials": 5, "n_warmup_steps": 50},
+        "sampler": {"type": "tpe", "seed": 42},
+        "search_space": {
+            "learning_rate": {"type": "log_float", "low": 5e-4, "high": 5e-3},
+            "batch_size": {"type": "categorical", "choices": [32, 64, 128]},
+            "hidden_channels": {"type": "categorical", "choices": [16, 32, 64]},
+            "dropout": {"type": "float", "low": 0.05, "high": 0.25},
+            "gamma": {"type": "float", "low": 2.0, "high": 5.0},
+            "weight_decay": {"type": "log_float", "low": 1e-4, "high": 1e-3},
+            "edge_drop_prob": {"type": "float", "low": 0.0, "high": 0.05},
+            "use_logit_adjust": {"type": "categorical", "choices": [True, False]},
+        },
+        "fixed_params": {
+            "epochs": 500,
+            "patience": 100,
+            "use_amp": True,
+            "use_class_frequency_sampler": True,
+            "data_usage_ratio": 1.0,
+        },
+        "hardware": {"nproc_per_node": 4},
+        "output": {"base_dir": "runs", "study_db_dir": "runs/hpo_studies"},
+    }
+
+    if config_path is None:
+        return defaults
+
+    path = Path(config_path)
+    if not path.exists():
+        print(f"[WARN] Config not found: {path}, using defaults")
+        return defaults
+
+    with open(path) as f:
+        raw = yaml.safe_load(f)
+
+    cfg = raw.get("hpo", raw)
+    for key, val in defaults.items():
+        cfg.setdefault(key, val)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Search space
+# ---------------------------------------------------------------------------
+
+def sample_hyperparams(trial: optuna.Trial, search_space: Dict[str, Any]) -> Dict[str, Any]:
+    """Sample hyperparameters from the search space using Optuna trial."""
+    params = {}
+    for name, spec in search_space.items():
+        ptype = spec["type"]
+        if ptype == "float":
+            params[name] = trial.suggest_float(name, spec["low"], spec["high"])
+        elif ptype == "log_float":
+            params[name] = trial.suggest_float(name, spec["low"], spec["high"], log=True)
+        elif ptype == "int":
+            params[name] = trial.suggest_int(name, spec["low"], spec["high"])
+        elif ptype == "categorical":
+            params[name] = trial.suggest_categorical(name, spec["choices"])
+        else:
+            raise ValueError(f"Unknown search space type: {ptype} for param {name}")
+    return params
+
+
+def sample_finetune_params(trial: optuna.Trial) -> Dict[str, Any]:
+    """Sample fine-tuning specific hyperparameters."""
+    strategy = trial.suggest_categorical("ft_strategy", ["freeze_backbone", "differential_lr", "higher_lr"])
+
+    params = {
+        "epochs": trial.suggest_categorical("epochs", [500, 1000]),
+        "patience": trial.suggest_categorical("patience", [100, 150, 200]),
+    }
+
+    if strategy == "freeze_backbone":
+        params["freeze_backbone"] = True
+        params["head_lr"] = trial.suggest_float("head_lr", 5e-4, 5e-3, log=True)
+    elif strategy == "differential_lr":
+        params["backbone_lr"] = trial.suggest_float("backbone_lr", 1e-5, 1e-3, log=True)
+        params["head_lr"] = trial.suggest_float("head_lr", 5e-4, 5e-3, log=True)
+    else:  # higher_lr
+        params["learning_rate"] = trial.suggest_float("learning_rate", 1e-4, 1e-3, log=True)
+
+    return params
+
+
+# ---------------------------------------------------------------------------
+# Objective function
+# ---------------------------------------------------------------------------
+
+def build_training_args(params: Dict[str, Any], fixed_params: Dict[str, Any]) -> List[str]:
+    """Convert param dict to training script CLI args."""
+    args = ["--"]
+    merged = {**fixed_params, **params}
+
+    for key, val in merged.items():
+        arg_key = f"--{key}"
+        if isinstance(val, bool):
+            if val:
+                args.append(arg_key)
+        else:
+            args.extend([arg_key, str(val)])
+
+    return args
+
+
+def run_trial_training(
+    run_id: str,
+    training_args: List[str],
+    output_base: Path,
+    nproc: int,
+    dry_run: bool = False,
+    pretrained_from: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Execute a single training run and return metrics."""
+    launcher = str(REPO_ROOT / "tools" / "launch_run.py")
+    cmd = [
+        sys.executable, launcher,
+        "--run_id", run_id,
+        "--output_base", str(output_base),
+        "--nproc_per_node", str(nproc),
+    ]
+    if dry_run:
+        cmd.append("--dry_run")
+
+    # Add fine-tune source if specified
+    extra_args = list(training_args)
+    if pretrained_from:
+        extra_args.extend(["--fine_tune_from", pretrained_from])
+
+    cmd.extend(extra_args)
+
+    run_dir = output_base / run_id
+
+    print(f"\n[HPO] {'DRY RUN: ' if dry_run else ''}Trial run: {run_id}")
+    print(f"  cmd: {' '.join(cmd[:10])}...")
+
+    if dry_run:
+        subprocess.run(cmd, cwd=str(REPO_ROOT))
+        return {"status": "dry_run", "macro_f1": 0.0}
+
+    result = subprocess.run(cmd, cwd=str(REPO_ROOT))
+
+    if result.returncode != 0:
+        print(f"[HPO] Trial {run_id} failed (exit_code={result.returncode})")
+        return {"status": "failed", "macro_f1": 0.0}
+
+    # Collect metrics
+    if run_dir.exists():
+        metrics = load_run_metrics(run_dir)
+        best_f1 = metrics.get("metrics", {}).get("best", {}).get("macro_f1")
+        if best_f1 is not None:
+            return {"status": "completed", "macro_f1": float(best_f1), "metrics": metrics}
+
+    return {"status": "no_metrics", "macro_f1": 0.0}
+
+
+def create_objective(
+    config: Dict[str, Any],
+    output_base: Path,
+    mode: str = "train",
+    pretrained_from: Optional[str] = None,
+    dry_run: bool = False,
+):
+    """Create an Optuna objective function."""
+    search_space = config.get("search_space", {})
+    fixed_params = config.get("fixed_params", {})
+    nproc = config.get("hardware", {}).get("nproc_per_node", 4)
+    study_name = config.get("study_name", "hpo")
+
+    def objective(trial: optuna.Trial) -> float:
+        # Sample hyperparameters
+        if mode == "finetune":
+            params = sample_finetune_params(trial)
+        else:
+            params = sample_hyperparams(trial, search_space)
+
+        # Build run ID
+        run_id = f"hpo_{study_name}_t{trial.number:03d}"
+
+        # Build training args
+        training_args = build_training_args(params, fixed_params)
+
+        # Execute training
+        result = run_trial_training(
+            run_id=run_id,
+            training_args=training_args,
+            output_base=output_base,
+            nproc=nproc,
+            dry_run=dry_run,
+            pretrained_from=pretrained_from,
+        )
+
+        macro_f1 = result.get("macro_f1", 0.0)
+
+        if result["status"] == "failed":
+            raise optuna.TrialPruned(f"Training failed for trial {trial.number}")
+
+        return macro_f1
+
+    return objective
+
+
+# ---------------------------------------------------------------------------
+# Study management
+# ---------------------------------------------------------------------------
+
+def create_study(config: Dict[str, Any]) -> optuna.Study:
+    """Create or load an Optuna study with SQLite storage."""
+    study_name = config.get("study_name", "cfrp_hpo")
+    direction = config.get("direction", "maximize")
+    db_dir = Path(config.get("output", {}).get("study_db_dir", "runs/hpo_studies"))
+    db_dir = REPO_ROOT / db_dir
+    db_dir.mkdir(parents=True, exist_ok=True)
+    db_path = db_dir / f"{study_name}.db"
+
+    storage = f"sqlite:///{db_path}"
+
+    # Pruner
+    pruner_cfg = config.get("pruner", {})
+    pruner_type = pruner_cfg.get("type", "median")
+    if pruner_type == "median":
+        pruner = optuna.pruners.MedianPruner(
+            n_startup_trials=pruner_cfg.get("n_startup_trials", 5),
+            n_warmup_steps=pruner_cfg.get("n_warmup_steps", 50),
+        )
+    else:
+        pruner = optuna.pruners.NopPruner()
+
+    # Sampler
+    sampler_cfg = config.get("sampler", {})
+    sampler_type = sampler_cfg.get("type", "tpe")
+    seed = sampler_cfg.get("seed", 42)
+    if sampler_type == "tpe":
+        sampler = optuna.samplers.TPESampler(seed=seed)
+    elif sampler_type == "random":
+        sampler = optuna.samplers.RandomSampler(seed=seed)
+    else:
+        sampler = optuna.samplers.TPESampler(seed=seed)
+
+    study = optuna.create_study(
+        study_name=study_name,
+        storage=storage,
+        direction=direction,
+        pruner=pruner,
+        sampler=sampler,
+        load_if_exists=True,
+    )
+
+    print(f"[HPO] Study: {study_name} (storage: {db_path})")
+    print(f"[HPO] Existing trials: {len(study.trials)}")
+
+    return study
+
+
+# ---------------------------------------------------------------------------
+# Export & visualization
+# ---------------------------------------------------------------------------
+
+def export_results(study: optuna.Study, output_dir: Path) -> None:
+    """Export study results to CSV, JSON, and generate visualizations."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Trials DataFrame
+    df = study.trials_dataframe()
+    csv_path = output_dir / "hpo_trials.csv"
+    df.to_csv(csv_path, index=False)
+    print(f"[HPO] Trials CSV: {csv_path}")
+
+    # Best trial summary
+    try:
+        best = study.best_trial
+        summary = {
+            "study_name": study.study_name,
+            "generated_at": _dt.datetime.now().isoformat(),
+            "n_trials": len(study.trials),
+            "n_complete": len([t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]),
+            "n_pruned": len([t for t in study.trials if t.state == optuna.trial.TrialState.PRUNED]),
+            "best_trial": {
+                "number": best.number,
+                "value": best.value,
+                "params": best.params,
+            },
+        }
+    except ValueError:
+        summary = {
+            "study_name": study.study_name,
+            "generated_at": _dt.datetime.now().isoformat(),
+            "n_trials": len(study.trials),
+            "best_trial": None,
+        }
+
+    json_path = output_dir / "hpo_summary.json"
+    with open(json_path, "w") as f:
+        json.dump(summary, f, indent=2, ensure_ascii=False, default=str)
+    print(f"[HPO] Summary JSON: {json_path}")
+
+    # Visualizations (matplotlib-based, no plotly dependency)
+    complete_trials = [t for t in study.trials if t.state == optuna.trial.TrialState.COMPLETE]
+    if len(complete_trials) < 2:
+        print("[HPO] Not enough completed trials for visualization")
+        return
+
+    try:
+        import matplotlib.pyplot as plt
+
+        # 1. Optimization history
+        fig, ax = plt.subplots(figsize=(10, 5))
+        values = [t.value for t in complete_trials]
+        numbers = [t.number for t in complete_trials]
+        best_so_far = np.maximum.accumulate(values)
+        ax.scatter(numbers, values, alpha=0.6, label="Trial value")
+        ax.plot(numbers, best_so_far, "r-", linewidth=2, label="Best so far")
+        ax.set_xlabel("Trial")
+        ax.set_ylabel("Macro F1")
+        ax.set_title("HPO Optimization History")
+        ax.legend()
+        fig.tight_layout()
+        fig.savefig(output_dir / "hpo_optimization_history.png", dpi=150)
+        plt.close(fig)
+        print(f"[HPO] Plot: {output_dir / 'hpo_optimization_history.png'}")
+
+        # 2. Parameter importance (simple correlation-based)
+        if len(complete_trials) >= 5:
+            param_names = list(complete_trials[0].params.keys())
+            importances = {}
+            for pname in param_names:
+                pvals = []
+                fvals = []
+                for t in complete_trials:
+                    if pname in t.params:
+                        pv = t.params[pname]
+                        if isinstance(pv, (int, float)):
+                            pvals.append(float(pv))
+                            fvals.append(t.value)
+                if len(pvals) >= 3:
+                    corr = abs(np.corrcoef(pvals, fvals)[0, 1])
+                    if not np.isnan(corr):
+                        importances[pname] = corr
+
+            if importances:
+                sorted_imp = sorted(importances.items(), key=lambda x: x[1], reverse=True)
+                names = [x[0] for x in sorted_imp]
+                vals = [x[1] for x in sorted_imp]
+
+                fig, ax = plt.subplots(figsize=(10, max(4, len(names) * 0.5)))
+                ax.barh(names, vals)
+                ax.set_xlabel("|Correlation| with Macro F1")
+                ax.set_title("Parameter Importance (correlation-based)")
+                fig.tight_layout()
+                fig.savefig(output_dir / "hpo_param_importance.png", dpi=150)
+                plt.close(fig)
+                print(f"[HPO] Plot: {output_dir / 'hpo_param_importance.png'}")
+
+    except Exception as e:
+        print(f"[WARN] Visualization failed: {e}")
+
+    # Human-readable summary
+    txt_path = output_dir / "hpo_summary.txt"
+    with open(txt_path, "w") as f:
+        f.write("=" * 60 + "\n")
+        f.write(f"HPO Summary: {study.study_name}\n")
+        f.write(f"Generated: {_dt.datetime.now().isoformat()}\n")
+        f.write(f"Total trials: {len(study.trials)}\n")
+        f.write(f"Complete: {len(complete_trials)}\n")
+        f.write("=" * 60 + "\n\n")
+
+        if summary.get("best_trial"):
+            bt = summary["best_trial"]
+            f.write(f"Best Trial #{bt['number']}: macro_f1 = {bt['value']:.4f}\n")
+            f.write("Parameters:\n")
+            for k, v in bt["params"].items():
+                f.write(f"  {k}: {v}\n")
+            f.write("\n")
+
+        f.write("--- All Trials ---\n")
+        for t in sorted(complete_trials, key=lambda x: x.value, reverse=True):
+            f.write(f"  Trial {t.number:3d}: macro_f1={t.value:.4f}  {t.params}\n")
+
+    print(f"[HPO] Summary: {txt_path}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Optuna HPO for CFRP GNN",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--config", type=str, default=None, help="HPO config YAML")
+    parser.add_argument("--study_name", type=str, default=None, help="Override study name")
+    parser.add_argument("--n_trials", type=int, default=None, help="Number of trials")
+    parser.add_argument("--epochs", type=int, default=None, help="Override epochs per trial")
+    parser.add_argument("--patience", type=int, default=None, help="Override patience")
+    parser.add_argument("--mode", type=str, default="train", choices=["train", "finetune"],
+                        help="HPO mode: train (from scratch) or finetune")
+    parser.add_argument("--pretrained_from", type=str, default=None,
+                        help="Path to pretrained model for finetune mode")
+    parser.add_argument("--output_dir", type=str, default=None, help="Output directory")
+    parser.add_argument("--nproc_per_node", type=int, default=None, help="Override GPU count")
+    parser.add_argument("--dry_run", action="store_true", help="Print commands without training")
+    parser.add_argument("--export_only", action="store_true",
+                        help="Export results from existing study (no new trials)")
+    args = parser.parse_args()
+
+    config = load_hpo_config(args.config)
+
+    # CLI overrides
+    if args.study_name:
+        config["study_name"] = args.study_name
+    if args.n_trials:
+        config["n_trials"] = args.n_trials
+    if args.epochs:
+        config.setdefault("fixed_params", {})["epochs"] = args.epochs
+    if args.patience:
+        config.setdefault("fixed_params", {})["patience"] = args.patience
+    if args.nproc_per_node:
+        config.setdefault("hardware", {})["nproc_per_node"] = args.nproc_per_node
+
+    # Output directory
+    ts = _dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    study_name = config.get("study_name", "hpo")
+    output_base = (
+        Path(args.output_dir) if args.output_dir
+        else REPO_ROOT / config.get("output", {}).get("base_dir", "runs") / f"hpo_{study_name}_{ts}"
+    )
+    output_base.mkdir(parents=True, exist_ok=True)
+
+    # Save config used
+    with open(output_base / "hpo_config_used.json", "w") as f:
+        json.dump(config, f, indent=2, ensure_ascii=False, default=str)
+
+    # Create study
+    study = create_study(config)
+
+    if args.export_only:
+        export_results(study, output_base)
+        return 0
+
+    # Create objective
+    objective = create_objective(
+        config=config,
+        output_base=output_base,
+        mode=args.mode,
+        pretrained_from=args.pretrained_from,
+        dry_run=args.dry_run,
+    )
+
+    n_trials = config.get("n_trials", 20)
+
+    print(f"\n[HPO] Starting optimization: {n_trials} trials")
+    print(f"[HPO] Study: {study_name}")
+    print(f"[HPO] Output: {output_base}")
+    print(f"[HPO] Mode: {args.mode}")
+    if args.pretrained_from:
+        print(f"[HPO] Pretrained from: {args.pretrained_from}")
+    print()
+
+    if args.dry_run:
+        # Run a few trials in dry-run mode
+        for i in range(min(n_trials, 3)):
+            trial = study.ask()
+            val = objective(trial)
+            study.tell(trial, val)
+        print(f"\n[DRY RUN] Would run {n_trials} trials. Output: {output_base}")
+        return 0
+
+    # Run optimization
+    study.optimize(objective, n_trials=n_trials, show_progress_bar=True)
+
+    # Export results
+    export_results(study, output_base)
+
+    print(f"\n[HPO] Done. Output: {output_base}")
+    if study.best_trial:
+        print(f"[HPO] Best trial #{study.best_trial.number}: macro_f1={study.best_trial.value:.4f}")
+        print(f"[HPO] Best params: {study.best_trial.params}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add Optuna-based HPO runner (`tools/optuna_hpo.py`) with TPE sampler, MedianPruner, SQLite storage for pause/resume
- Add fine-tuning strategy comparison (`tools/finetune_comparison.py`): freeze_backbone / differential_lr / higher_lr × N seeds
- Extend `tools/analyze_sweeps.py` with `--optuna_db` support for Optuna study analysis
- Add `optuna>=3.0.0` to requirements.txt

## Files Changed
| File | Change |
|------|--------|
| `tools/optuna_hpo.py` | **New**: Optuna HPO runner |
| `tools/hpo_config.yaml` | **New**: HPO config (search space, pruner, fixed params) |
| `tools/finetune_comparison.py` | **New**: 3 strategies × N seeds comparison |
| `tools/analyze_sweeps.py` | Add `--optuna_db` / `load_optuna_study()` |
| `requirements.txt` | Add `optuna>=3.0.0` |
| `tests/test_hpo.py` | **New**: 15 unit tests |

## Test plan
- [x] `python -m unittest tests.test_hpo -v` — 15 tests pass
- [x] `python tools/optuna_hpo.py --n_trials 2 --epochs 5 --dry_run` — dry run verified
- [ ] `python tools/optuna_hpo.py --n_trials 5 --epochs 100` — short HPO run
- [ ] `python tools/finetune_comparison.py --pretrained_from <model> --dry_run`

## Wiki
- [HPO Optuna (Issue #4)](https://github.com/keisuke58/nishioka_cfrp_gnn/wiki/HPO-Optuna-(Issue-%234))

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)